### PR TITLE
Fix: Video processing now returns complete videos with censored audio

### DIFF
--- a/app/workers/remuxWorker.ts
+++ b/app/workers/remuxWorker.ts
@@ -1,0 +1,100 @@
+import { FFmpeg } from "@ffmpeg/ffmpeg";
+import { toBlobURL } from "@ffmpeg/util";
+
+// Helper to get correct public path
+function getPublicPath(path: string) {
+  // In production, adjust for GitHub Pages subdirectory
+  const basePath = self.location.pathname.includes('/bleep-that-shit')
+    ? '/bleep-that-shit'
+    : '';
+  return `${basePath}${path}`;
+}
+
+let ffmpeg: FFmpeg | null = null;
+
+async function loadFFmpeg() {
+  if (ffmpeg && ffmpeg.loaded) return ffmpeg;
+
+  ffmpeg = new FFmpeg();
+
+  const baseURL = 'https://unpkg.com/@ffmpeg/core@0.12.6/dist/umd';
+  await ffmpeg.load({
+    coreURL: await toBlobURL(`${baseURL}/ffmpeg-core.js`, 'text/javascript'),
+    wasmURL: await toBlobURL(`${baseURL}/ffmpeg-core.wasm`, 'application/wasm'),
+  });
+
+  return ffmpeg;
+}
+
+self.onmessage = async (event: MessageEvent) => {
+  const { type, videoBuffer, audioBuffer } = event.data;
+
+  try {
+    if (type === "remux") {
+      self.postMessage({ status: "Loading FFmpeg...", progress: 0 });
+
+      const ffmpeg = await loadFFmpeg();
+
+      self.postMessage({ status: "Processing video...", progress: 20 });
+
+      // Write input files
+      await ffmpeg.writeFile("input_video.mp4", new Uint8Array(videoBuffer));
+      await ffmpeg.writeFile("censored_audio.wav", new Uint8Array(audioBuffer));
+
+      self.postMessage({ status: "Remuxing video with censored audio...", progress: 40 });
+
+      // Remux video with new audio
+      // -c:v copy - copy video codec without re-encoding
+      // -c:a aac - encode audio to AAC
+      // -shortest - finish encoding when shortest input ends
+      await ffmpeg.exec([
+        "-i", "input_video.mp4",
+        "-i", "censored_audio.wav",
+        "-c:v", "copy",
+        "-c:a", "aac",
+        "-map", "0:v:0",
+        "-map", "1:a:0",
+        "-shortest",
+        "output.mp4"
+      ]);
+
+      self.postMessage({ status: "Reading output...", progress: 80 });
+
+      // Read the output file
+      const outputData = await ffmpeg.readFile("output.mp4");
+
+      // Clean up files to free memory
+      await ffmpeg.deleteFile("input_video.mp4");
+      await ffmpeg.deleteFile("censored_audio.wav");
+      await ffmpeg.deleteFile("output.mp4");
+
+      self.postMessage({ status: "Complete!", progress: 100 });
+
+      // Handle both Uint8Array and string types
+      if (outputData instanceof Uint8Array) {
+        const buffer = outputData.buffer as ArrayBuffer;
+        (self as any).postMessage(
+          { type: "complete", videoBuffer: buffer },
+          [buffer]
+        );
+      } else {
+        // Convert string to Uint8Array if necessary
+        const encoder = new TextEncoder();
+        const uint8Array = encoder.encode(outputData as string);
+        const buffer = uint8Array.buffer as ArrayBuffer;
+        (self as any).postMessage(
+          { type: "complete", videoBuffer: buffer },
+          [buffer]
+        );
+      }
+    }
+  } catch (error: any) {
+    self.postMessage({
+      type: "error",
+      error: error.message,
+      stack: error.stack
+    });
+  }
+};
+
+export {};

--- a/tests/video-bleeping.spec.ts
+++ b/tests/video-bleeping.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+test.describe('Video Bleeping Test', () => {
+  test('should process video and return censored video (not just audio)', async ({ page }) => {
+    test.setTimeout(240000); // 4 minutes for full video processing
+
+    // Enable console logging
+    page.on('console', msg => {
+      console.log(`[${msg.type()}] ${msg.text()}`);
+    });
+
+    console.log('1. Navigating to bleep page...');
+    await page.goto('/bleep');
+    await expect(page.locator('h1').filter({ hasText: 'Bleep Your Sh*t!' })).toBeVisible();
+
+    // Upload video file
+    console.log('2. Uploading video file...');
+    const videoFile = path.join(__dirname, 'fixtures/files/test.mp4');
+    const fileInput = page.locator('input[type="file"]');
+    await fileInput.setInputFiles(videoFile);
+
+    // Wait for file to be loaded
+    await expect(page.locator('text=/File loaded/')).toBeVisible({ timeout: 10000 });
+    console.log('3. Video file uploaded successfully');
+
+    // Verify video preview
+    const videoPreview = page.locator('video').first();
+    await expect(videoPreview).toBeVisible();
+    console.log('4. Video preview is visible');
+
+    // Select model
+    console.log('5. Selecting model...');
+    const modelSelect = page.locator('select').nth(1);
+    await modelSelect.selectOption('Xenova/whisper-tiny.en');
+
+    // Start transcription
+    console.log('6. Starting transcription...');
+    const transcribeBtn = page.locator('button').filter({ hasText: 'Start Transcription' });
+    await expect(transcribeBtn).toBeEnabled();
+    await transcribeBtn.click();
+
+    // Wait for transcription to complete
+    console.log('7. Waiting for transcription...');
+    const transcriptDiv = await page.waitForSelector('text=/Transcript:/', { timeout: 120000 });
+    const transcriptText = await page.locator('p.text-gray-800').first().textContent();
+    console.log(`Transcript: "${transcriptText}"`);
+
+    // Enter words to bleep (simple test words)
+    console.log('8. Setting words to bleep...');
+    await page.fill('input[placeholder*="bad, word, curse"]', 'the, a, and');
+
+    // Enable exact matching
+    await page.check('input[type="checkbox"]', { hasText: /Exact match/ });
+
+    // Run matching
+    console.log('9. Running word matching...');
+    const matchBtn = page.locator('button').filter({ hasText: 'Run Matching' });
+    await matchBtn.click();
+
+    // Wait for matched words
+    await expect(page.locator('text=/Matched.*words:/')).toBeVisible({ timeout: 10000 });
+    const matchedCount = await page.locator('.bg-yellow-200').count();
+    console.log(`10. Matched ${matchedCount} words`);
+
+    // Apply bleeps
+    console.log('11. Applying bleeps to video...');
+    const bleepBtn = page.locator('button').filter({ hasText: 'Apply Bleeps!' });
+    await bleepBtn.click();
+
+    // Wait for processing (this is where video remuxing happens)
+    console.log('12. Waiting for video processing...');
+
+    // Check for processing indicator
+    const processingText = page.locator('text=/Processing video/');
+    if (await processingText.isVisible({ timeout: 5000 }).catch(() => false)) {
+      console.log('Video processing indicator detected');
+    }
+
+    // Wait for censored result
+    const censoredResult = await page.waitForSelector('h3:has-text("Censored Result:")', { timeout: 120000 });
+    console.log('13. Censored result available');
+
+    // CRITICAL: Check if we have a video player for the output (not just audio)
+    const censoredVideo = page.locator('video').last();
+    const censoredAudio = page.locator('audio').last();
+
+    const hasVideoOutput = await censoredVideo.isVisible().catch(() => false);
+    const hasAudioOutput = await censoredAudio.isVisible().catch(() => false);
+
+    console.log(`Output type: Video=${hasVideoOutput}, Audio=${hasAudioOutput}`);
+
+    // Check download button text
+    const downloadBtn = page.locator('a[download]').last();
+    const downloadText = await downloadBtn.textContent();
+    const downloadFileName = await downloadBtn.getAttribute('download');
+
+    console.log(`Download button: "${downloadText}", filename: "${downloadFileName}"`);
+
+    // Take screenshot
+    await page.screenshot({
+      path: 'test-results/video-bleeping-result.png',
+      fullPage: true
+    });
+
+    // Assertions
+    expect(hasVideoOutput).toBe(true);
+    expect(downloadText).toContain('Download Censored Video');
+    expect(downloadFileName).toContain('.mp4');
+
+    console.log('✅ Video bleeping test passed - returns video, not just audio!');
+  });
+});


### PR DESCRIPTION
## Summary
- Fixed video processing to return complete video files instead of just audio
- Implemented proper video remuxing with FFmpeg.wasm
- Updated UI to handle video output correctly

## Problem
Previously, when users uploaded MP4 video files for censoring, the app would only return the extracted audio after applying bleeps. The video stream was lost in the process.

## Solution
Implemented a complete video processing pipeline that:
1. Extracts audio from the video
2. Applies bleeps to the audio track
3. Remuxes the censored audio with the original video stream
4. Returns a complete MP4 file

## Changes
- **Added `remuxWorker.ts`**: New web worker that handles video remuxing using FFmpeg.wasm
- **Implemented `applyBleepsToVideo`**: Full implementation that extracts, processes, and remuxes video
- **Updated UI**: 
  - Shows video player for video output (not audio player)
  - Displays "Download Censored Video" button with `.mp4` extension
  - Added processing indicator for video remuxing
- **Added test**: Comprehensive test for video bleeping functionality

## Testing
- [x] Tested with `test.mp4` fixture file
- [x] Verified video player appears for video output
- [x] Confirmed download provides complete MP4 file
- [x] Build compiles without errors
- [x] Added automated test for video processing

## Test Instructions
1. Navigate to `/bleep`
2. Upload an MP4 video file
3. Transcribe and select words to censor
4. Apply bleeps
5. Verify the output is a video player (not audio)
6. Download and verify the file is a complete MP4

Fixes #43

🤖 Generated with [Claude Code](https://claude.ai/code)