### PR TITLE
Add Discord community links throughout the app

### DIFF
--- a/app/bleep/page.tsx
+++ b/app/bleep/page.tsx
@@ -661,7 +661,20 @@ export default function BleepPage() {
           >
             <div className="flex items-start">
               <span className="mr-2">⚠️</span>
-              <div>{fileDurationWarning}</div>
+              <div>
+                {fileDurationWarning}
+                <span className="ml-1 text-sm">
+                  Need help with longer files?{' '}
+                  <a
+                    href="https://discord.gg/8EUxqR93"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-indigo-600 underline hover:text-indigo-800"
+                  >
+                    Ask on Discord
+                  </a>
+                </span>
+              </div>
             </div>
           </div>
         )}
@@ -795,12 +808,22 @@ export default function BleepPage() {
               <div className="flex-1">
                 <p className="font-semibold text-red-800">Transcription Error</p>
                 <p className="mt-1 text-sm text-red-700">{errorMessage}</p>
-                <button
-                  onClick={() => setErrorMessage(null)}
-                  className="mt-2 text-sm text-red-600 underline hover:text-red-800"
-                >
-                  Dismiss
-                </button>
+                <div className="mt-2 flex items-center gap-3">
+                  <button
+                    onClick={() => setErrorMessage(null)}
+                    className="text-sm text-red-600 underline hover:text-red-800"
+                  >
+                    Dismiss
+                  </button>
+                  <a
+                    href="https://discord.gg/8EUxqR93"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-indigo-600 underline hover:text-indigo-800"
+                  >
+                    Get help on Discord
+                  </a>
+                </div>
               </div>
             </div>
           </div>
@@ -829,6 +852,17 @@ export default function BleepPage() {
               <div>
                 <strong>Timestamp Quality Warning:</strong> {timestampWarning.count} out of{' '}
                 {timestampWarning.total} words had invalid timestamps and were filtered out.
+                <div className="mt-2 text-sm">
+                  Having issues?{' '}
+                  <a
+                    href="https://discord.gg/8EUxqR93"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-indigo-600 underline hover:text-indigo-800"
+                  >
+                    Get help on Discord
+                  </a>
+                </div>
               </div>
             </div>
           </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -225,6 +225,35 @@ export default function Home() {
           </a>
         </div>
       </section>
+
+      {/* Divider */}
+      <div className="mx-auto my-10 h-0.5 w-24 rounded bg-black md:w-40"></div>
+
+      {/* Community Section */}
+      <section data-testid="community-section" className="editorial-section mb-16">
+        <div className="flex flex-col items-center text-center">
+          <h2
+            className="font-inter mb-4 text-2xl font-extrabold text-black uppercase sm:text-3xl md:text-4xl"
+            style={{ lineHeight: 1.1 }}
+          >
+            Join Our Community
+          </h2>
+          <p className="mb-6 max-w-xl text-base text-gray-800 sm:text-lg md:text-xl">
+            Have questions, feature requests, or found a bug? Join our Discord community to get
+            help, share feedback, and stay updated on new features and improvements.
+          </p>
+          <a
+            data-testid="discord-link"
+            href="https://discord.gg/8EUxqR93"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-3 rounded-lg bg-gradient-to-r from-indigo-600 to-purple-600 px-8 py-3.5 text-base font-semibold text-white transition-all hover:from-indigo-700 hover:to-purple-700 hover:shadow-lg sm:text-lg"
+          >
+            <i className="fab fa-discord text-2xl"></i>
+            <span>Join Discord</span>
+          </a>
+        </div>
+      </section>
     </div>
   );
 }

--- a/components/Footer.test.tsx
+++ b/components/Footer.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { Footer } from './Footer';
 
@@ -58,6 +58,14 @@ describe('Footer', () => {
     expect(blogLink).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
+  it('renders Discord link with correct attributes', () => {
+    render(<Footer />);
+    const discordLink = screen.getByLabelText('Join Discord community');
+    expect(discordLink).toHaveAttribute('href', 'https://discord.gg/8EUxqR93');
+    expect(discordLink).toHaveAttribute('target', '_blank');
+    expect(discordLink).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
   it('displays the current year in copyright', () => {
     render(<Footer />);
     expect(
@@ -70,29 +78,11 @@ describe('Footer', () => {
     const githubIcon = container.querySelector('.fa-github');
     const twitterIcon = container.querySelector('.fa-x-twitter');
     const blogIcon = container.querySelector('.fa-globe');
+    const discordIcon = container.querySelector('.fa-discord');
 
     expect(githubIcon).toBeInTheDocument();
     expect(twitterIcon).toBeInTheDocument();
     expect(blogIcon).toBeInTheDocument();
-  });
-
-  it('renders newsletter subscribe button with correct attributes', () => {
-    render(<Footer />);
-    const newsletterButton = screen.getByRole('link', {
-      name: /get updates on projects like this/i,
-    });
-    expect(newsletterButton).toHaveAttribute('href', 'https://neonwatty.com/newsletter/');
-    expect(newsletterButton).toHaveAttribute('target', '_blank');
-    expect(newsletterButton).toHaveAttribute('rel', 'noopener noreferrer');
-  });
-
-  it('displays newsletter button with emoji', () => {
-    render(<Footer />);
-    expect(screen.getByText(/📬/)).toBeInTheDocument();
-  });
-
-  it('displays newsletter subtitle text', () => {
-    render(<Footer />);
-    expect(screen.getByText(/Occasional updates • No spam/i)).toBeInTheDocument();
+    expect(discordIcon).toBeInTheDocument();
   });
 });

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -41,17 +41,15 @@ export function Footer() {
           >
             <i className="fas fa-globe text-2xl"></i>
           </a>
-        </div>
-        <div className="flex flex-col items-center gap-1">
           <a
-            href="https://neonwatty.com/newsletter/"
+            href="https://discord.gg/8EUxqR93"
             target="_blank"
             rel="noopener noreferrer"
-            className="rounded-lg bg-gradient-to-r from-violet-600 to-indigo-600 px-6 py-2.5 text-sm font-semibold text-white transition-all hover:from-violet-700 hover:to-indigo-700 hover:shadow-lg"
+            className="text-gray-700 transition-colors hover:text-black"
+            aria-label="Join Discord community"
           >
-            📬 Get updates on projects like this
+            <i className="fab fa-discord text-2xl"></i>
           </a>
-          <span className="text-xs text-gray-500">Occasional updates • No spam</span>
         </div>
         <div className="text-center text-xs text-gray-600">
           © {new Date().getFullYear()} Bleep That Sh*t! All rights reserved.

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -150,6 +150,15 @@ export function MobileNav() {
               >
                 <i className="fas fa-globe text-2xl"></i>
               </a>
+              <a
+                href="https://discord.gg/8EUxqR93"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-gray-700 hover:text-black"
+                aria-label="Discord"
+              >
+                <i className="fab fa-discord text-2xl"></i>
+              </a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
- Add Discord icon to Footer and Mobile Navigation (all pages)
- Add "Join Our Community" CTA section on home page
- Add subtle Discord help links on bleep page (errors/warnings)
- Remove newsletter links and replace with Discord
- Update Footer tests to reflect Discord additions

This provides users easy access to community support exactly where they need it - in error states, warnings, and prominent CTAs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)