### PR TITLE
feat: add silence mode option to bleep sound dropdown

### DIFF
--- a/app/bleep/hooks/useBleepState.ts
+++ b/app/bleep/hooks/useBleepState.ts
@@ -67,10 +67,18 @@ export function useBleepState() {
   const [wordSource, setWordSource] = useState<Map<number, 'manual' | number>>(new Map());
 
   // Bleep configuration state
-  const [bleepSound, setBleepSound] = useState('bleep');
+  const [bleepSound, setBleepSoundInternal] = useState('bleep');
   const [bleepVolume, setBleepVolume] = useState(80);
   const [originalVolumeReduction, setOriginalVolumeReduction] = useState(0.0);
   const [bleepBuffer, setBleepBuffer] = useState<number>(0);
+
+  // Handler to auto-set volume when silence is selected
+  const setBleepSound = useCallback((sound: string) => {
+    setBleepSoundInternal(sound);
+    if (sound === 'silence') {
+      setOriginalVolumeReduction(0);
+    }
+  }, []);
   const [censoredMediaUrl, setCensoredMediaUrl] = useState<string | null>(null);
   const [isProcessingVideo, setIsProcessingVideo] = useState(false);
   const [isPreviewingBleep, setIsPreviewingBleep] = useState(false);

--- a/components/BleepControls.test.tsx
+++ b/components/BleepControls.test.tsx
@@ -109,14 +109,29 @@ describe('BleepControls', () => {
     render(<BleepControls {...defaultProps} isPreviewingBleep={false} />);
 
     const button = screen.getByTestId('preview-bleep-button');
-    expect(button).toHaveTextContent('🔊 Preview Bleep');
+    expect(button).toHaveTextContent('Preview Bleep');
   });
 
   it('shows "Playing..." text when previewing', () => {
     render(<BleepControls {...defaultProps} isPreviewingBleep={true} />);
 
     const button = screen.getByTestId('preview-bleep-button');
-    expect(button).toHaveTextContent('🔊 Playing...');
+    expect(button).toHaveTextContent('Playing...');
+  });
+
+  it('shows "Silence Mode" text when silence is selected', () => {
+    render(<BleepControls {...defaultProps} bleepSound="silence" />);
+
+    const button = screen.getByTestId('preview-bleep-button');
+    expect(button).toHaveTextContent('Silence Mode');
+    expect(button).toBeDisabled();
+  });
+
+  it('disables bleep volume slider when silence is selected', () => {
+    render(<BleepControls {...defaultProps} bleepSound="silence" />);
+
+    const slider = screen.getByTestId('bleep-volume-slider');
+    expect(slider).toBeDisabled();
   });
 
   it('calls onPreviewBleep when preview button is clicked', () => {

--- a/components/BleepControls.tsx
+++ b/components/BleepControls.tsx
@@ -37,12 +37,20 @@ export function BleepControls({
           <option value="brown">Brown Noise</option>
           <option value="dolphin">Dolphin Sounds Bleep</option>
           <option value="trex">T-Rex Roar</option>
+          <option value="silence">Silence (No Sound)</option>
         </select>
       </div>
 
       <div>
-        <label className="mb-2 block text-sm font-semibold">
-          Bleep Volume: <span className="font-bold text-yellow-600">{bleepVolume}%</span>
+        <label
+          className={`mb-2 block text-sm font-semibold ${bleepSound === 'silence' ? 'text-gray-400' : ''}`}
+        >
+          Bleep Volume:{' '}
+          <span
+            className={`font-bold ${bleepSound === 'silence' ? 'text-gray-400' : 'text-yellow-600'}`}
+          >
+            {bleepSound === 'silence' ? 'N/A' : `${bleepVolume}%`}
+          </span>
         </label>
         <input
           data-testid="bleep-volume-slider"
@@ -52,7 +60,8 @@ export function BleepControls({
           step="5"
           value={bleepVolume}
           onChange={e => onBleepVolumeChange(Number(e.target.value))}
-          className="h-2 w-full cursor-pointer rounded-lg sm:max-w-xs"
+          disabled={bleepSound === 'silence'}
+          className={`h-2 w-full rounded-lg sm:max-w-xs ${bleepSound === 'silence' ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}`}
         />
         <div className="mt-1 flex w-full justify-between text-xs text-gray-600 sm:max-w-xs">
           <span>Quiet</span>
@@ -109,10 +118,14 @@ export function BleepControls({
         <button
           data-testid="preview-bleep-button"
           onClick={onPreviewBleep}
-          disabled={isPreviewingBleep}
+          disabled={isPreviewingBleep || bleepSound === 'silence'}
           className="min-h-touch mt-3 w-full rounded-lg bg-yellow-500 px-6 py-3 text-base font-semibold text-white transition-colors hover:bg-yellow-600 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:px-4 sm:py-2 sm:text-sm"
         >
-          {isPreviewingBleep ? '🔊 Playing...' : '🔊 Preview Bleep'}
+          {bleepSound === 'silence'
+            ? 'Silence Mode'
+            : isPreviewingBleep
+              ? 'Playing...'
+              : 'Preview Bleep'}
         </button>
       </div>
     </div>


### PR DESCRIPTION
Add "Silence (No Sound)" option that completely removes audio during censored segments without playing a bleep sound. When selected:
- Bleep volume slider is disabled and shows "N/A"
- Preview button is disabled and shows "Silence Mode"
- Original volume is automatically set to 0 (fully muted)
- Audio processor skips loading bleep sound file

🤖 Generated with [Claude Code](https://claude.com/claude-code)