### PR TITLE
fix: update Discord invite link and add link validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Validate Discord invite link
+        run: |
+          DISCORD_URL="https://discord.gg/XuzjVXyjH4"
+          echo "Checking Discord invite link: $DISCORD_URL"
+          HTTP_STATUS=$(curl -o /dev/null -s -w "%{http_code}" -L "$DISCORD_URL")
+          echo "HTTP Status: $HTTP_STATUS"
+          if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 400 ]; then
+            echo "✅ Discord link is valid (HTTP $HTTP_STATUS)"
+          else
+            echo "❌ Discord link returned HTTP $HTTP_STATUS"
+            exit 1
+          fi
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,46 @@
+name: Link Validation
+
+on:
+  schedule:
+    # Run daily at 9:00 AM UTC
+    - cron: '0 9 * * *'
+  workflow_dispatch: # Allow manual triggers
+
+jobs:
+  check-links:
+    name: Validate External Links
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate Discord invite link
+        run: |
+          DISCORD_URL="https://discord.gg/XuzjVXyjH4"
+
+          echo "Checking Discord invite link: $DISCORD_URL"
+
+          # Use curl to check the link, following redirects
+          HTTP_STATUS=$(curl -o /dev/null -s -w "%{http_code}" -L "$DISCORD_URL")
+
+          echo "HTTP Status: $HTTP_STATUS"
+
+          if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 400 ]; then
+            echo "✅ Discord link is valid (HTTP $HTTP_STATUS)"
+          else
+            echo "❌ Discord link returned HTTP $HTTP_STATUS"
+            exit 1
+          fi
+
+      - name: Report status
+        if: failure()
+        run: |
+          echo "::error::Discord invite link validation failed! Please check if the invite is still valid."
+          echo "Update the link in the following files if needed:"
+          echo "  - lib/constants/structuredData.ts"
+          echo "  - components/Footer.tsx"
+          echo "  - components/MobileNav.tsx"
+          echo "  - components/FileUpload.tsx"
+          echo "  - app/page.tsx"
+          echo "  - app/bleep/components/SetupTranscribeTab.tsx"

--- a/app/bleep/components/SetupTranscribeTab.test.tsx
+++ b/app/bleep/components/SetupTranscribeTab.test.tsx
@@ -178,7 +178,7 @@ describe('SetupTranscribeTab', () => {
 
       const discordLink = screen.getByText('Get help on Discord');
       expect(discordLink).toBeInTheDocument();
-      expect(discordLink).toHaveAttribute('href', 'https://discord.gg/8EUxqR93');
+      expect(discordLink).toHaveAttribute('href', 'https://discord.gg/XuzjVXyjH4');
       expect(discordLink).toHaveAttribute('target', '_blank');
       expect(discordLink).toHaveAttribute('rel', 'noopener noreferrer');
     });

--- a/app/bleep/components/SetupTranscribeTab.tsx
+++ b/app/bleep/components/SetupTranscribeTab.tsx
@@ -157,7 +157,7 @@ export function SetupTranscribeTab({
                     Dismiss
                   </button>
                   <a
-                    href="https://discord.gg/8EUxqR93"
+                    href="https://discord.gg/XuzjVXyjH4"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-sm text-indigo-600 underline hover:text-indigo-800"
@@ -201,7 +201,7 @@ export function SetupTranscribeTab({
                 <div className="mt-2 text-sm">
                   Having issues?{' '}
                   <a
-                    href="https://discord.gg/8EUxqR93"
+                    href="https://discord.gg/XuzjVXyjH4"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-indigo-600 underline hover:text-indigo-800"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -347,7 +347,7 @@ export default function Home() {
             </p>
             <a
               data-testid="discord-link"
-              href="https://discord.gg/8EUxqR93"
+              href="https://discord.gg/XuzjVXyjH4"
               target="_blank"
               rel="noopener noreferrer"
               className="flex items-center gap-3 rounded-lg bg-gradient-to-r from-indigo-600 to-purple-600 px-8 py-3.5 text-base font-semibold text-white transition-all hover:from-indigo-700 hover:to-purple-700 hover:shadow-lg sm:text-lg"

--- a/components/FileUpload.test.tsx
+++ b/components/FileUpload.test.tsx
@@ -126,7 +126,7 @@ describe('FileUpload', () => {
 
     const link = screen.getByRole('link', { name: /Ask on Discord/i });
     expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute('href', 'https://discord.gg/8EUxqR93');
+    expect(link).toHaveAttribute('href', 'https://discord.gg/XuzjVXyjH4');
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });

--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -91,7 +91,7 @@ export function FileUpload({
               <span className="ml-1 text-sm">
                 Need help with longer files?{' '}
                 <a
-                  href="https://discord.gg/8EUxqR93"
+                  href="https://discord.gg/XuzjVXyjH4"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-indigo-600 underline hover:text-indigo-800"

--- a/components/Footer.test.tsx
+++ b/components/Footer.test.tsx
@@ -59,7 +59,7 @@ describe('Footer', () => {
   it('renders Discord link with correct attributes', () => {
     render(<Footer />);
     const discordLink = screen.getByLabelText('Join Discord community');
-    expect(discordLink).toHaveAttribute('href', 'https://discord.gg/8EUxqR93');
+    expect(discordLink).toHaveAttribute('href', 'https://discord.gg/XuzjVXyjH4');
     expect(discordLink).toHaveAttribute('target', '_blank');
     expect(discordLink).toHaveAttribute('rel', 'noopener noreferrer');
   });

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -43,7 +43,7 @@ export function Footer() {
             <i className="fas fa-blog text-2xl"></i>
           </Link>
           <a
-            href="https://discord.gg/8EUxqR93"
+            href="https://discord.gg/XuzjVXyjH4"
             target="_blank"
             rel="noopener noreferrer"
             className="text-gray-700 transition-colors hover:text-black"

--- a/components/MobileNav.test.tsx
+++ b/components/MobileNav.test.tsx
@@ -256,7 +256,7 @@ describe('MobileNav', () => {
       fireEvent.click(menuButton);
 
       const discordLink = screen.getByLabelText('Discord');
-      expect(discordLink).toHaveAttribute('href', 'https://discord.gg/8EUxqR93');
+      expect(discordLink).toHaveAttribute('href', 'https://discord.gg/XuzjVXyjH4');
       expect(discordLink).toHaveAttribute('target', '_blank');
       expect(discordLink).toHaveAttribute('rel', 'noopener noreferrer');
     });

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -151,7 +151,7 @@ export function MobileNav() {
                 <i className="fas fa-globe text-2xl"></i>
               </a>
               <a
-                href="https://discord.gg/8EUxqR93"
+                href="https://discord.gg/XuzjVXyjH4"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-gray-700 hover:text-black"

--- a/lib/constants/externalLinks.test.ts
+++ b/lib/constants/externalLinks.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+
+// Central constant for the Discord invite URL
+// This is validated by the daily link-check GitHub workflow
+export const DISCORD_URL = 'https://discord.gg/XuzjVXyjH4';
+
+describe('External Links Validation', () => {
+  describe('Discord Link', () => {
+    it('should have a valid Discord invite URL format', () => {
+      expect(DISCORD_URL).toMatch(/^https:\/\/discord\.gg\/[A-Za-z0-9]+$/);
+    });
+
+    it('should use the discord.gg shortlink domain', () => {
+      expect(DISCORD_URL).toContain('discord.gg/');
+    });
+
+    it('should have the expected invite code', () => {
+      // This ensures the invite code hasn't been accidentally modified
+      expect(DISCORD_URL).toBe('https://discord.gg/XuzjVXyjH4');
+    });
+  });
+});

--- a/lib/constants/structuredData.ts
+++ b/lib/constants/structuredData.ts
@@ -12,7 +12,7 @@ export const organizationSchema = {
     width: 512,
     height: 512,
   },
-  sameAs: ['https://github.com/neonwatty/bleep-that-shit', 'https://discord.gg/8EUxqR93'],
+  sameAs: ['https://github.com/neonwatty/bleep-that-shit', 'https://discord.gg/XuzjVXyjH4'],
 };
 
 export const websiteSchema = {


### PR DESCRIPTION
## Summary
- Replace broken Discord invite link with new URL (`https://discord.gg/XuzjVXyjH4`)
- Add unit tests validating Discord URL format
- Add daily GitHub workflow for automated link health checks
- Add link validation step to main CI workflow

## Test plan
- [x] All unit tests pass (922 tests)
- [ ] CI workflow validates Discord link returns valid HTTP status
- [ ] Daily link-check workflow is properly configured