### PR TITLE
feat: add feedback collection CTAs for user research

### DIFF
--- a/app/bleep/components/BleepDownloadTab.test.tsx
+++ b/app/bleep/components/BleepDownloadTab.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { BleepDownloadTab } from './BleepDownloadTab';
+import { FEEDBACK_FORM_URL } from '@/lib/constants/externalLinks';
 
 describe('BleepDownloadTab', () => {
   const mockMatchedWords = [
@@ -414,6 +415,39 @@ describe('BleepDownloadTab', () => {
       expect(button).toHaveTextContent('Re-apply Bleeps with New Settings');
       expect(button).toHaveClass('animate-pulse');
       expect(screen.getByText(/Volume changed from 80% to 120%/)).toBeInTheDocument();
+    });
+  });
+
+  describe('Feedback CTA', () => {
+    it('shows feedback CTA when censored result is available', () => {
+      const mockFile = new File(['content'], 'test.mp3', { type: 'audio/mp3' });
+      render(
+        <BleepDownloadTab {...defaultProps} file={mockFile} censoredMediaUrl="blob:test-url" />
+      );
+
+      expect(screen.getByText(/Was this helpful\?/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/We're building new features and would love your input/)
+      ).toBeInTheDocument();
+    });
+
+    it('renders feedback form link with correct attributes', () => {
+      const mockFile = new File(['content'], 'test.mp3', { type: 'audio/mp3' });
+      render(
+        <BleepDownloadTab {...defaultProps} file={mockFile} censoredMediaUrl="blob:test-url" />
+      );
+
+      const feedbackLink = screen.getByRole('link', { name: /Share Quick Feedback/i });
+      expect(feedbackLink).toBeInTheDocument();
+      expect(feedbackLink).toHaveAttribute('href', FEEDBACK_FORM_URL);
+      expect(feedbackLink).toHaveAttribute('target', '_blank');
+      expect(feedbackLink).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
+    it('does not show feedback CTA when no censored result', () => {
+      render(<BleepDownloadTab {...defaultProps} censoredMediaUrl={null} />);
+
+      expect(screen.queryByText(/Was this helpful\?/)).not.toBeInTheDocument();
     });
   });
 });

--- a/app/bleep/components/BleepDownloadTab.tsx
+++ b/app/bleep/components/BleepDownloadTab.tsx
@@ -2,6 +2,7 @@ import { BleepControls } from '@/components/BleepControls';
 import { FloatingNavArrows } from './FloatingNavArrows';
 import type { MatchedWord } from '../hooks/useBleepState';
 import { trackEvent } from '@/lib/analytics';
+import { FEEDBACK_FORM_URL } from '@/lib/constants/externalLinks';
 
 interface BleepDownloadTabProps {
   file: File | null;
@@ -185,6 +186,23 @@ export function BleepDownloadTab({
                   </span>
                 )}
               </p>
+            </div>
+
+            {/* Feedback CTA */}
+            <div className="mt-4 rounded border-l-4 border-yellow-400 bg-yellow-50 p-3">
+              <p className="text-sm text-yellow-900">
+                <strong>Was this helpful?</strong> We&apos;re building new features and would love
+                your input.
+              </p>
+              <a
+                href={FEEDBACK_FORM_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-2 inline-block rounded bg-yellow-500 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-yellow-600"
+                onClick={() => trackEvent('feedback_cta_clicked', { location: 'download_success' })}
+              >
+                Share Quick Feedback (30 sec)
+              </a>
             </div>
           </div>
         )}

--- a/components/FileUpload.test.tsx
+++ b/components/FileUpload.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { FileUpload } from './FileUpload';
+import { FEEDBACK_FORM_LONG_FILES_URL } from '@/lib/constants/externalLinks';
 
 // Mock react-dropzone
 vi.mock('react-dropzone', () => ({
@@ -129,6 +130,17 @@ describe('FileUpload', () => {
     expect(link).toHaveAttribute('href', 'https://discord.gg/XuzjVXyjH4');
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('displays email notification signup CTA in duration warning', () => {
+    render(<FileUpload {...defaultProps} fileDurationWarning="Warning message" />);
+
+    expect(screen.getByText(/We're working on longer video support/i)).toBeInTheDocument();
+    const notifyLink = screen.getByRole('link', { name: /Get notified when it's ready/i });
+    expect(notifyLink).toBeInTheDocument();
+    expect(notifyLink).toHaveAttribute('href', FEEDBACK_FORM_LONG_FILES_URL);
+    expect(notifyLink).toHaveAttribute('target', '_blank');
+    expect(notifyLink).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
   it('displays file name when file is loaded', () => {

--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -1,4 +1,5 @@
 import { useDropzone } from 'react-dropzone';
+import { FEEDBACK_FORM_LONG_FILES_URL } from '@/lib/constants/externalLinks';
 
 interface FileUploadProps {
   onFileUpload: (file: File) => void;
@@ -88,8 +89,19 @@ export function FileUpload({
             <span className="mr-2">⚠️</span>
             <div>
               {fileDurationWarning}
-              <span className="ml-1 text-sm">
-                Need help with longer files?{' '}
+              <div className="mt-2 rounded bg-orange-200 p-2">
+                <p className="text-sm font-medium">We&apos;re working on longer video support.</p>
+                <a
+                  href={FEEDBACK_FORM_LONG_FILES_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-1 inline-block rounded bg-orange-500 px-3 py-1 text-sm font-semibold text-white transition-colors hover:bg-orange-600"
+                >
+                  Get notified when it&apos;s ready
+                </a>
+              </div>
+              <span className="mt-2 block text-sm">
+                Need help now?{' '}
                 <a
                   href="https://discord.gg/XuzjVXyjH4"
                   target="_blank"

--- a/components/Footer.test.tsx
+++ b/components/Footer.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { Footer } from './Footer';
+import { FEEDBACK_FORM_URL } from '@/lib/constants/externalLinks';
 
 describe('Footer', () => {
   const originalDate = Date;
@@ -82,5 +83,19 @@ describe('Footer', () => {
     expect(twitterIcon).toBeInTheDocument();
     expect(blogIcon).toBeInTheDocument();
     expect(discordIcon).toBeInTheDocument();
+  });
+
+  it('renders feedback link with correct attributes', () => {
+    render(<Footer />);
+    const feedbackLink = screen.getByLabelText('Share feedback');
+    expect(feedbackLink).toHaveAttribute('href', FEEDBACK_FORM_URL);
+    expect(feedbackLink).toHaveAttribute('target', '_blank');
+    expect(feedbackLink).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('renders feedback icon', () => {
+    const { container } = render(<Footer />);
+    const feedbackIcon = container.querySelector('.fa-comment-dots');
+    expect(feedbackIcon).toBeInTheDocument();
   });
 });

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { version } from '../package.json';
+import { FEEDBACK_FORM_URL } from '@/lib/constants/externalLinks';
 
 export function Footer() {
   return (
@@ -50,6 +51,15 @@ export function Footer() {
             aria-label="Join Discord community"
           >
             <i className="fab fa-discord text-2xl"></i>
+          </a>
+          <a
+            href={FEEDBACK_FORM_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-gray-700 transition-colors hover:text-black"
+            aria-label="Share feedback"
+          >
+            <i className="fas fa-comment-dots text-2xl"></i>
           </a>
         </div>
         <div className="text-center text-xs text-gray-600">

--- a/lib/constants/externalLinks.test.ts
+++ b/lib/constants/externalLinks.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect } from 'vitest';
-
-// Central constant for the Discord invite URL
-// This is validated by the daily link-check GitHub workflow
-export const DISCORD_URL = 'https://discord.gg/XuzjVXyjH4';
+import { DISCORD_URL, FEEDBACK_FORM_URL, FEEDBACK_FORM_LONG_FILES_URL } from './externalLinks';
 
 describe('External Links Validation', () => {
   describe('Discord Link', () => {
@@ -17,6 +14,28 @@ describe('External Links Validation', () => {
     it('should have the expected invite code', () => {
       // This ensures the invite code hasn't been accidentally modified
       expect(DISCORD_URL).toBe('https://discord.gg/XuzjVXyjH4');
+    });
+  });
+
+  describe('Feedback Form Links', () => {
+    it('should have a valid Google Forms URL format for primary feedback form', () => {
+      expect(FEEDBACK_FORM_URL).toMatch(/^https:\/\/forms\.gle\/[A-Za-z0-9]+$/);
+    });
+
+    it('should have a valid Google Forms URL format for long files form', () => {
+      expect(FEEDBACK_FORM_LONG_FILES_URL).toMatch(/^https:\/\/forms\.gle\/[A-Za-z0-9]+$/);
+    });
+
+    it('should have the expected primary feedback form URL', () => {
+      expect(FEEDBACK_FORM_URL).toBe('https://forms.gle/NbsDZeTWMVXe5Q1R8');
+    });
+
+    it('should have the expected long files form URL', () => {
+      expect(FEEDBACK_FORM_LONG_FILES_URL).toBe('https://forms.gle/FKCSYGe95oa9p7Ey9');
+    });
+
+    it('should use different forms for different purposes', () => {
+      expect(FEEDBACK_FORM_URL).not.toBe(FEEDBACK_FORM_LONG_FILES_URL);
     });
   });
 });

--- a/lib/constants/externalLinks.ts
+++ b/lib/constants/externalLinks.ts
@@ -1,0 +1,10 @@
+// Central constant for the Discord invite URL
+// This is validated by the daily link-check GitHub workflow
+export const DISCORD_URL = 'https://discord.gg/XuzjVXyjH4';
+
+// Google Form URLs for feedback collection
+// Primary feedback form - shown after successful export and in footer
+export const FEEDBACK_FORM_URL = 'https://forms.gle/NbsDZeTWMVXe5Q1R8';
+
+// Short email capture form - shown when file exceeds 10-minute limit
+export const FEEDBACK_FORM_LONG_FILES_URL = 'https://forms.gle/FKCSYGe95oa9p7Ey9';


### PR DESCRIPTION
## Summary

- Add Google Form feedback CTAs at three strategic locations to collect user feedback before Reddit ad campaign
- Primary feedback form shown after successful export and in footer
- Short email capture form shown when file exceeds 10-minute limit
- Extract form URLs to centralized constants file for maintainability

## Changes

| Location | Component | Form |
|----------|-----------|------|
| After download | `BleepDownloadTab.tsx` | Primary feedback (7 questions) |
| File too long | `FileUpload.tsx` | Email capture (2 questions) |
| Footer | `Footer.tsx` | Primary feedback |

## New Files

- `lib/constants/externalLinks.ts` - Centralized external URL constants

## Test plan

- [x] Unit tests for all three CTA locations
- [x] URL validation tests in `externalLinks.test.ts`
- [x] Build passes
- [x] All 933 unit tests pass
- [ ] Manual testing of CTAs in browser
- [ ] Verify form links open correct Google Forms