### PR TITLE
fix: reduce button sizes for better mobile/desktop UX

### DIFF
--- a/app/bleep/components/ReviewMatchTab.tsx
+++ b/app/bleep/components/ReviewMatchTab.tsx
@@ -510,12 +510,12 @@ export function ReviewMatchTab({
                         )}
                       </div>
 
-                      <div className="flex gap-2">
+                      <div className="flex flex-wrap gap-2">
                         <button
                           data-testid="run-matching-button"
                           onClick={onMatch}
                           disabled={!transcriptionResult || !wordsToMatch}
-                          className="btn btn-secondary disabled:cursor-not-allowed disabled:opacity-50"
+                          className="btn btn-sm btn-secondary disabled:cursor-not-allowed disabled:opacity-50"
                         >
                           Match Words
                         </button>
@@ -523,7 +523,7 @@ export function ReviewMatchTab({
                           <button
                             data-testid="clear-all-button"
                             onClick={onClearAll}
-                            className="btn bg-gray-500 text-white hover:bg-gray-600"
+                            className="btn btn-sm bg-gray-500 text-white hover:bg-gray-600"
                           >
                             Clear All
                           </button>

--- a/app/globals.css
+++ b/app/globals.css
@@ -69,6 +69,21 @@ h6 {
   }
 }
 
+/* Smaller button variant for inline/compact contexts */
+.btn-sm {
+  padding: 0.5rem 1rem;
+  font-size: 0.75rem;
+  min-height: 36px;
+  width: auto;
+}
+
+@media (min-width: 640px) {
+  .btn-sm {
+    padding: 0.625rem 1.25rem;
+    font-size: 0.875rem;
+  }
+}
+
 .btn-primary {
   background: #181818;
   color: #fff;

--- a/components/BleepControls.tsx
+++ b/components/BleepControls.tsx
@@ -163,7 +163,7 @@ export function BleepControls({
           data-testid="preview-bleep-button"
           onClick={onPreviewBleep}
           disabled={isPreviewingBleep || bleepSound === 'silence'}
-          className="min-h-touch mt-3 w-full rounded-lg bg-yellow-500 px-6 py-3 text-base font-semibold text-white transition-colors hover:bg-yellow-600 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:px-4 sm:py-2 sm:text-sm"
+          className="mt-3 min-h-[36px] w-auto rounded-lg bg-yellow-500 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-yellow-600 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {bleepSound === 'silence'
             ? 'Silence Mode'

--- a/components/wordsets/WordsetSelector.tsx
+++ b/components/wordsets/WordsetSelector.tsx
@@ -109,17 +109,17 @@ export function WordsetSelector({
           </div>
 
           {/* Action Buttons */}
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2">
             <button
               onClick={handleApply}
               disabled={selectedWordsets.size === 0}
-              className="btn btn-primary disabled:cursor-not-allowed disabled:opacity-50"
+              className="btn btn-sm btn-primary disabled:cursor-not-allowed disabled:opacity-50"
               data-testid="apply-wordsets-button"
             >
               Apply Selected ({selectedWordsets.size})
             </button>
             {onManageClick && (
-              <button onClick={onManageClick} className="btn btn-secondary">
+              <button onClick={onManageClick} className="btn btn-sm btn-secondary">
                 Manage Wordsets
               </button>
             )}


### PR DESCRIPTION
## Summary

- Add `.btn-sm` CSS class variant for compact buttons
- Apply smaller sizing to buttons in Review & Match tab
- Reduce Preview Bleep button size

## Changes

| Component | Buttons | Change |
|-----------|---------|--------|
| `ReviewMatchTab.tsx` | Match Words, Clear All | Added `btn-sm` class |
| `WordsetSelector.tsx` | Apply Selected, Manage Wordsets | Added `btn-sm` class |
| `BleepControls.tsx` | Preview Bleep | Reduced from full-width to compact |

## New CSS Class

```css
.btn-sm {
  padding: 0.5rem 1rem;      /* 8px 16px */
  font-size: 0.75rem;        /* 12px */
  min-height: 36px;
  width: auto;
}
```

## Test plan

- [x] All 933 unit tests pass
- [x] Build succeeds
- [x] Manual testing of button sizes on desktop
- [ ] Verify buttons render correctly in CI