### PR TITLE
feat: add premium landing page mock-up

### DIFF
--- a/mock-ups/premium-landing.html
+++ b/mock-ups/premium-landing.html
@@ -254,7 +254,7 @@
       <p class="text-gray-600 mb-8">
         Free version stays free forever. Premium is for power users.
       </p>
-      <a href="https://forms.gle/PLACEHOLDER" target="_blank" class="inline-block bg-gradient-to-r from-indigo-600 to-purple-600 px-12 py-5 rounded-xl font-bold text-xl hover:from-indigo-500 hover:to-purple-500 transition-all hover:scale-105 shadow-lg shadow-indigo-500/25">
+      <a href="https://docs.google.com/forms/d/e/1FAIpQLSfsLPN_1a6NZlLSaaYz6DcsVPU85ZIcqFMV9-pygbRyF_XHyg/viewform" target="_blank" class="inline-block bg-gradient-to-r from-indigo-600 to-purple-600 px-12 py-5 rounded-xl font-bold text-xl hover:from-indigo-500 hover:to-purple-500 transition-all hover:scale-105 shadow-lg shadow-indigo-500/25">
         Join Premium Waitlist →
       </a>
     </div>


### PR DESCRIPTION
## Summary

- Adds a static HTML mock-up for the premium landing page design
- Located at `mock-ups/premium-landing.html`
- Can be previewed by opening directly in a browser

## Design Features

**Hero Section (Split Layout)**
- Bold gradient typography: "Bleep Faster. Longer. Smarter."
- Feature cards with gradient borders on the right side

**Premium Features Highlighted**
- 10x Faster Processing (server-side OpenAI Whisper)
- 2+ Hour Files (no more 10-minute limits)
- Saved Projects (pick up where you left off)
- Project History (re-edit and re-export anytime)

**Use Cases Section**
- Teachers & Educators
- Podcasters
- YouTube Creators
- Production Teams
- Each with testimonial quotes

**Other Sections**
- Social proof stats (10K+ files, 500+ Discord members)
- Free vs Premium comparison
- Waitlist CTA with 50% off early bird messaging

## Visual Style

- Dark mode aesthetic (#000 / gray-950 backgrounds)
- Indigo → Purple → Pink gradient accents
- Inter font for headlines, Merriweather for body
- Matches existing app styling patterns

## Test plan

- [ ] Open `mock-ups/premium-landing.html` in browser
- [ ] Verify responsive layout on desktop and mobile viewports
- [ ] Check all links (waitlist, Discord, back to home)