### PR TITLE
fix: change "server" to "cloud" terminology on premium page

### DIFF
--- a/app/premium/layout.tsx
+++ b/app/premium/layout.tsx
@@ -4,7 +4,7 @@ import { SITE_URL } from '@/lib/constants/structuredData';
 export const metadata: Metadata = {
   title: 'Premium Features - Coming Soon | Bleep That Sh*t!',
   description:
-    'Process 2+ hour files with 10x faster server-side processing. Save projects, re-edit anytime. Join the waitlist for early access.',
+    'Process 2+ hour files with 10x faster cloud processing. Save projects, re-edit anytime. Join the waitlist for early access.',
   openGraph: {
     title: 'Bleep That Sh*t! Premium - Coming Soon',
     description:

--- a/app/premium/page.tsx
+++ b/app/premium/page.tsx
@@ -8,7 +8,7 @@ const features = [
   {
     emoji: '⚡',
     title: '10x Faster Processing',
-    description: 'Server-side OpenAI Whisper API',
+    description: 'Cloud-powered OpenAI Whisper API',
   },
   {
     emoji: '⏱️',
@@ -118,7 +118,7 @@ export default function PremiumPage() {
             </h1>
 
             <p className="font-merriweather mt-8 max-w-md text-xl text-gray-400">
-              Premium unlocks server-powered processing, 2+ hour files, and saved projects.
+              Premium unlocks cloud-powered processing, 2+ hour files, and saved projects.
             </p>
 
             <div className="mt-8 flex flex-col gap-4 sm:flex-row">
@@ -247,7 +247,7 @@ export default function PremiumPage() {
               </h3>
               <ul className="space-y-3">
                 <li>✓ 2+ hour files</li>
-                <li>✓ 10x faster server processing</li>
+                <li>✓ 10x faster cloud processing</li>
                 <li>✓ Saved projects</li>
                 <li>✓ Project history & re-export</li>
                 <li>✓ Team features</li>

--- a/tests/e2e/premium.spec.ts
+++ b/tests/e2e/premium.spec.ts
@@ -114,7 +114,7 @@ test.describe('Premium Page Tests', () => {
     await expect(page).toHaveTitle(/Premium/);
 
     const metaDescription = page.locator('meta[name="description"]');
-    await expect(metaDescription).toHaveAttribute('content', /server-side processing/i);
+    await expect(metaDescription).toHaveAttribute('content', /cloud processing/i);
   });
 
   test('should have Discord link in footer', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Replace "server" terminology with "cloud" on the premium landing page to reduce reader confusion
- Updated 4 instances across `page.tsx` and `layout.tsx` (including meta description)

## Test plan
- [ ] Verify premium page renders correctly at `/premium`
- [ ] Check meta description in page source