### PR TITLE
feat: add whisper-medium timestamped models for higher accuracy transcription

### DIFF
--- a/app/sampler/page.tsx
+++ b/app/sampler/page.tsx
@@ -61,9 +61,19 @@ function SamplerPageContent() {
     { id: 'Xenova/whisper-tiny.en', name: 'Tiny (fastest, lower accuracy)', size: '~50 MB' },
     { id: 'Xenova/whisper-base.en', name: 'Base (balanced, recommended)', size: '~85 MB' },
     { id: 'Xenova/whisper-small.en', name: 'Small (best accuracy)', size: '~275 MB' },
+    {
+      id: 'onnx-community/whisper-medium.en_timestamped',
+      name: 'Medium (highest accuracy, slowest)',
+      size: '~800 MB',
+    },
     { id: 'Xenova/whisper-tiny', name: 'Tiny Multilingual (90+ languages)', size: '~50 MB' },
     { id: 'Xenova/whisper-base', name: 'Base Multilingual (recommended)', size: '~85 MB' },
     { id: 'Xenova/whisper-small', name: 'Small Multilingual (best accuracy)', size: '~275 MB' },
+    {
+      id: 'onnx-community/whisper-medium_timestamped',
+      name: 'Medium Multilingual (highest accuracy, slowest)',
+      size: '~800 MB',
+    },
   ];
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({

--- a/app/workers/transcriptionSamplerWorker.ts
+++ b/app/workers/transcriptionSamplerWorker.ts
@@ -13,8 +13,13 @@ self.onmessage = async (event: MessageEvent) => {
     );
     self.postMessage({ progress: 10, status: `Loading ${model}...` });
 
+    // Determine revision: Xenova models need 'output_attentions' branch,
+    // but onnx-community timestamped models have timestamps in main branch
+    const isTimestampedModel = model.includes('_timestamped');
+    const revision = isTimestampedModel ? 'main' : 'output_attentions';
+
     const transcriber = await pipeline('automatic-speech-recognition', model, {
-      revision: 'output_attentions', // Use revision with cross-attention outputs for accurate word-level timestamps
+      revision,
       progress_callback: (progress: any) => {
         if (progress && progress.progress !== undefined) {
           // Check if progress.progress is already a percentage (0-100) or decimal (0-1)

--- a/components/TranscriptionControls.test.tsx
+++ b/components/TranscriptionControls.test.tsx
@@ -71,9 +71,11 @@ describe('TranscriptionControls', () => {
     expect(select).toHaveTextContent('Tiny (~50 MB, fastest, lower accuracy)');
     expect(select).toHaveTextContent('Base (~85 MB, balanced, recommended)');
     expect(select).toHaveTextContent('Small (~275 MB, best accuracy, slower)');
+    expect(select).toHaveTextContent('Medium (~800 MB, highest accuracy, slowest)');
     expect(select).toHaveTextContent('Tiny Multilingual (~50 MB, 90+ languages)');
     expect(select).toHaveTextContent('Base Multilingual (~85 MB, recommended)');
     expect(select).toHaveTextContent('Small Multilingual (~275 MB, best accuracy)');
+    expect(select).toHaveTextContent('Medium Multilingual (~800 MB, highest accuracy, slowest)');
   });
 
   it('has correct model option values', () => {
@@ -86,9 +88,11 @@ describe('TranscriptionControls', () => {
       'Xenova/whisper-tiny.en',
       'Xenova/whisper-base.en',
       'Xenova/whisper-small.en',
+      'onnx-community/whisper-medium.en_timestamped',
       'Xenova/whisper-tiny',
       'Xenova/whisper-base',
       'Xenova/whisper-small',
+      'onnx-community/whisper-medium_timestamped',
     ]);
   });
 
@@ -137,9 +141,11 @@ describe('TranscriptionControls', () => {
       'Xenova/whisper-tiny.en',
       'Xenova/whisper-base.en',
       'Xenova/whisper-small.en',
+      'onnx-community/whisper-medium.en_timestamped',
       'Xenova/whisper-tiny',
       'Xenova/whisper-base',
       'Xenova/whisper-small',
+      'onnx-community/whisper-medium_timestamped',
     ];
     const select = screen.getByTestId('model-select');
 

--- a/components/TranscriptionControls.tsx
+++ b/components/TranscriptionControls.tsx
@@ -51,9 +51,15 @@ export function TranscriptionControls({
           <option value="Xenova/whisper-tiny.en">Tiny (~50 MB, fastest, lower accuracy)</option>
           <option value="Xenova/whisper-base.en">Base (~85 MB, balanced, recommended)</option>
           <option value="Xenova/whisper-small.en">Small (~275 MB, best accuracy, slower)</option>
+          <option value="onnx-community/whisper-medium.en_timestamped">
+            Medium (~800 MB, highest accuracy, slowest)
+          </option>
           <option value="Xenova/whisper-tiny">Tiny Multilingual (~50 MB, 90+ languages)</option>
           <option value="Xenova/whisper-base">Base Multilingual (~85 MB, recommended)</option>
           <option value="Xenova/whisper-small">Small Multilingual (~275 MB, best accuracy)</option>
+          <option value="onnx-community/whisper-medium_timestamped">
+            Medium Multilingual (~800 MB, highest accuracy, slowest)
+          </option>
         </select>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add onnx-community/whisper-medium.en_timestamped (English) and whisper-medium_timestamped (Multilingual) models to transcription dropdowns
- These models provide the highest accuracy but are slower due to larger size (~800 MB)
- Auto-detect `_timestamped` models and use `main` revision instead of `output_attentions` branch
- Increase model loading timeout from 30s to 5min for medium models

## Test plan
- [x] Unit tests updated and passing (935 tests)
- [ ] Manual testing of medium model transcription on bleep page
- [ ] Manual testing of medium model in sampler page
- [ ] Verify existing Xenova models still work correctly