### PR TITLE
refactor: update domain from bleep-that-sht.com to bleep-that-shit.com

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,7 +21,7 @@ const merriweather = Merriweather({
 
 // Get base path for production
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
-const siteUrl = 'https://bleep-that-sht.com';
+const siteUrl = 'https://bleep-that-shit.com';
 
 export const viewport: Viewport = {
   width: 'device-width',

--- a/lib/constants/structuredData.ts
+++ b/lib/constants/structuredData.ts
@@ -1,4 +1,4 @@
-export const SITE_URL = 'https://bleep-that-sht.com';
+export const SITE_URL = 'https://bleep-that-shit.com';
 export const SITE_NAME = 'Bleep That Sh*t!';
 
 export const organizationSchema = {

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,1 @@
-bleep-that-sht.com
+bleep-that-shit.com

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://bleep-that-sht.com/sitemap.xml
+Sitemap: https://bleep-that-shit.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,79 +1,79 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://bleep-that-sht.com/</loc>
+    <loc>https://bleep-that-shit.com/</loc>
     <lastmod>2025-12-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://bleep-that-sht.com/bleep</loc>
+    <loc>https://bleep-that-shit.com/bleep</loc>
     <lastmod>2025-12-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://bleep-that-sht.com/blog</loc>
+    <loc>https://bleep-that-shit.com/blog</loc>
     <lastmod>2025-11-28</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://bleep-that-sht.com/sampler</loc>
+    <loc>https://bleep-that-shit.com/sampler</loc>
     <lastmod>2025-12-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://bleep-that-sht.com/blog/bleep-out-words-video-free-online</loc>
+    <loc>https://bleep-that-shit.com/blog/bleep-out-words-video-free-online</loc>
     <lastmod>2025-12-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://bleep-that-sht.com/blog/bleep-words-video-without-capcut-imovie-premiere</loc>
+    <loc>https://bleep-that-shit.com/blog/bleep-words-video-without-capcut-imovie-premiere</loc>
     <lastmod>2025-12-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://bleep-that-sht.com/blog/bleep-youtube-videos-before-upload</loc>
+    <loc>https://bleep-that-shit.com/blog/bleep-youtube-videos-before-upload</loc>
     <lastmod>2025-12-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://bleep-that-sht.com/blog/censor-audio-video-online-free</loc>
+    <loc>https://bleep-that-shit.com/blog/censor-audio-video-online-free</loc>
     <lastmod>2025-12-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://bleep-that-sht.com/blog/censor-videos-for-classroom-teacher-guide</loc>
+    <loc>https://bleep-that-shit.com/blog/censor-videos-for-classroom-teacher-guide</loc>
     <lastmod>2025-12-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://bleep-that-sht.com/blog/how-to-bleep-words-in-video</loc>
+    <loc>https://bleep-that-shit.com/blog/how-to-bleep-words-in-video</loc>
     <lastmod>2025-12-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://bleep-that-sht.com/blog/how-to-censor-videos-on-chromebook</loc>
+    <loc>https://bleep-that-shit.com/blog/how-to-censor-videos-on-chromebook</loc>
     <lastmod>2025-12-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://bleep-that-sht.com/for-educators</loc>
+    <loc>https://bleep-that-shit.com/for-educators</loc>
     <lastmod>2025-12-27</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://bleep-that-sht.com/premium</loc>
+    <loc>https://bleep-that-shit.com/premium</loc>
     <lastmod>2025-12-27</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>

--- a/scripts/generate-sitemap.ts
+++ b/scripts/generate-sitemap.ts
@@ -12,7 +12,7 @@ import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 
-const SITE_URL = 'https://bleep-that-sht.com';
+const SITE_URL = 'https://bleep-that-shit.com';
 const APP_DIR = path.join(process.cwd(), 'app');
 const CONTENT_DIR = path.join(process.cwd(), 'content');
 const OUTPUT_PATH = path.join(process.cwd(), 'public', 'sitemap.xml');

--- a/tests/e2e/seo.spec.ts
+++ b/tests/e2e/seo.spec.ts
@@ -10,7 +10,7 @@
 
 import { test, expect } from './e2e-setup';
 
-const SITE_URL = 'https://bleep-that-sht.com';
+const SITE_URL = 'https://bleep-that-shit.com';
 
 test.describe('SEO - Home Page', () => {
   test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
## Summary
- Switch primary domain to the full spelling (bleep-that-shit.com) for better brand clarity
- Updated SITE_URL constant in structuredData.ts and generate-sitemap.ts
- Updated sitemap.xml, robots.txt, and CNAME files
- Updated E2E test constants

## Test plan
- [ ] Verify sitemap generates correctly with new domain
- [ ] Run E2E tests to ensure SEO tests pass with new URLs
- [ ] Verify DNS is pointing to new Cloudflare nameservers