### PR TITLE
feat: add auth feature flag to hide auth in production

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -38,3 +38,8 @@
 
 # App Configuration
 # NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Feature Flags
+# Set to 'true' to enable auth features (login/signup/dashboard)
+# Leave unset or 'false' for production to hide auth
+# NEXT_PUBLIC_AUTH_ENABLED=true

--- a/components/auth/AuthButton.tsx
+++ b/components/auth/AuthButton.tsx
@@ -4,9 +4,15 @@ import { useState, useRef, useEffect } from 'react';
 import Link from 'next/link';
 import { useAuth } from '@/providers/AuthProvider';
 import { UsageMeter } from '@/components/dashboard/UsageMeter';
+import { isAuthEnabled } from '@/lib/config/featureFlags';
 
 export function AuthButton() {
   const { user, profile, isLoading, isPremium, signOut } = useAuth();
+
+  // Hide auth button if auth is disabled (production)
+  if (!isAuthEnabled) {
+    return null;
+  }
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 

--- a/lib/config/featureFlags.ts
+++ b/lib/config/featureFlags.ts
@@ -1,0 +1,8 @@
+/**
+ * Feature flags for controlling feature visibility across environments.
+ *
+ * Set NEXT_PUBLIC_AUTH_ENABLED=true in your Vercel staging environment
+ * to enable auth features. Leave it unset or false for production.
+ */
+
+export const isAuthEnabled = process.env.NEXT_PUBLIC_AUTH_ENABLED === 'true';

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,10 +1,13 @@
 import { type NextRequest, NextResponse } from 'next/server';
 
+// Check if auth features are enabled (set in Vercel environment)
+const isAuthEnabled = process.env.NEXT_PUBLIC_AUTH_ENABLED === 'true';
+
 // Routes that require authentication
 const protectedRoutes = ['/dashboard'];
 
 // Routes that should redirect to dashboard if already authenticated
-const authRoutes = ['/auth/login', '/auth/signup'];
+const authRoutes = ['/auth/login', '/auth/signup', '/auth/reset-password', '/auth/update-password'];
 
 /**
  * Check if user has a valid auth session by looking for Supabase auth cookies.
@@ -29,6 +32,11 @@ export function middleware(request: NextRequest) {
   // Check if route needs auth handling
   const isProtectedRoute = protectedRoutes.some(route => pathname.startsWith(route));
   const isAuthRoute = authRoutes.some(route => pathname.startsWith(route));
+
+  // If auth is disabled, redirect all auth-related routes to home
+  if (!isAuthEnabled && (isAuthRoute || isProtectedRoute)) {
+    return NextResponse.redirect(new URL('/', request.url));
+  }
 
   // Skip middleware for routes that don't need auth
   if (!isProtectedRoute && !isAuthRoute) {


### PR DESCRIPTION
## Summary
- Add `NEXT_PUBLIC_AUTH_ENABLED` feature flag to control auth visibility
- Middleware redirects `/auth/*` and `/dashboard` routes to home when flag is disabled
- `AuthButton` component hides when auth is disabled
- Updated `.env.local.example` with feature flag documentation

## How it works
- **Production (default)**: Auth routes redirect to home, Sign In button hidden
- **Staging/Development**: Set `NEXT_PUBLIC_AUTH_ENABLED=true` to enable auth features

## Test plan
- [x] Auth routes redirect to home when `NEXT_PUBLIC_AUTH_ENABLED` is not set
- [x] Auth features work normally when `NEXT_PUBLIC_AUTH_ENABLED=true`
- [x] AuthButton is hidden in production, visible in staging