### PR TITLE
ci: add develop and staging branches to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, staging, develop]
   push:
-    branches: [main]
+    branches: [main, staging, develop]
 
 jobs:
   lint-and-test:


### PR DESCRIPTION
## Summary
- Run CI on PRs and pushes to develop, staging, and main branches
- Enables branch protection status checks for the new branches

## Test plan
- [x] CI runs on PRs to main (existing)
- [ ] CI runs on PRs to develop
- [ ] CI runs on PRs to staging