### PR TITLE
feat: auto-inject version from GitHub release tag

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -32,6 +32,7 @@ jobs:
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          NEXT_PUBLIC_APP_VERSION: ${{ github.event.release.tag_name }}
 
       - name: Deploy to Production
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -2,8 +2,11 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { version } from '../package.json';
+import { version as packageVersion } from '../package.json';
 import { FEEDBACK_FORM_URL } from '@/lib/constants/externalLinks';
+
+// Use release tag version in production, fallback to package.json
+const version = process.env.NEXT_PUBLIC_APP_VERSION || packageVersion;
 
 export function Footer() {
   const pathname = usePathname();


### PR DESCRIPTION
## Summary
- Update `deploy-production.yml` to set `NEXT_PUBLIC_APP_VERSION` from the release tag
- Update Footer to prefer release tag version over package.json

## How It Works

| Environment | Version Displayed |
|-------------|-------------------|
| **Production** (from release) | Release tag (e.g., `v1.0.0`) |
| **Preview/Development** | package.json version |

## Test Plan
- [ ] Verify typecheck passes
- [ ] Create a test release and verify version displays correctly