### PR TITLE
chore: test Vercel ignored build step configuration

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,6 @@
 import type { NextConfig } from "next";
 
+// Next.js configuration for bleep-that-shit
 const nextConfig: NextConfig = {
   // Keep images unoptimized for WASM/Transformers.js compatibility
   images: {


### PR DESCRIPTION
## Summary
- Tests that production auto-builds are disabled while preview/staging builds still work
- Adds a minor comment to next.config.ts

## Test plan
- [ ] Verify this PR creates a preview deployment on Vercel
- [ ] After merge, verify main branch creates staging deployment but NOT production