### PR TITLE
feat: add Account tab to BottomTabBar for logged-in users

### DIFF
--- a/components/BottomTabBar.test.tsx
+++ b/components/BottomTabBar.test.tsx
@@ -7,11 +7,53 @@ vi.mock('next/navigation', () => ({
   usePathname: vi.fn(() => '/'),
 }));
 
+// Mock useAuth hook
+vi.mock('@/providers/AuthProvider', () => ({
+  useAuth: vi.fn(() => ({
+    user: null,
+    session: null,
+    profile: null,
+    isLoading: false,
+    isPremium: false,
+    subscriptionTier: 'free',
+    signIn: vi.fn(),
+    signUp: vi.fn(),
+    signInWithOAuth: vi.fn(),
+    signInWithMagicLink: vi.fn(),
+    signOut: vi.fn(),
+    resetPassword: vi.fn(),
+    updatePassword: vi.fn(),
+    refreshProfile: vi.fn(),
+  })),
+}));
+
+// Mock feature flags
+vi.mock('@/lib/config/featureFlags', () => ({
+  isAuthEnabled: false,
+}));
+
 import { usePathname } from 'next/navigation';
+import { useAuth } from '@/providers/AuthProvider';
 
 describe('BottomTabBar', () => {
   beforeEach(() => {
     vi.mocked(usePathname).mockReturnValue('/');
+    vi.mocked(useAuth).mockReturnValue({
+      user: null,
+      session: null,
+      profile: null,
+      isLoading: false,
+      isPremium: false,
+      subscriptionTier: 'free',
+      signIn: vi.fn(),
+      signUp: vi.fn(),
+      signInWithOAuth: vi.fn(),
+      signInWithMagicLink: vi.fn(),
+      signOut: vi.fn(),
+      resetPassword: vi.fn(),
+      updatePassword: vi.fn(),
+      refreshProfile: vi.fn(),
+    });
   });
 
   describe('Tab rendering', () => {
@@ -140,6 +182,45 @@ describe('BottomTabBar', () => {
 
       const nav = container.querySelector('nav');
       expect(nav).toHaveClass('z-50');
+    });
+  });
+
+  describe('Account tab (authenticated user)', () => {
+    it('does not show Account tab when user is not logged in', () => {
+      vi.mocked(useAuth).mockReturnValue({
+        user: null,
+        session: null,
+        profile: null,
+        isLoading: false,
+        isPremium: false,
+        subscriptionTier: 'free',
+        signIn: vi.fn(),
+        signUp: vi.fn(),
+        signInWithOAuth: vi.fn(),
+        signInWithMagicLink: vi.fn(),
+        signOut: vi.fn(),
+        resetPassword: vi.fn(),
+        updatePassword: vi.fn(),
+        refreshProfile: vi.fn(),
+      });
+
+      render(<BottomTabBar />);
+
+      expect(screen.queryByText('Account')).not.toBeInTheDocument();
+    });
+
+    it('is hidden on dashboard pages', () => {
+      vi.mocked(usePathname).mockReturnValue('/dashboard');
+      const { container } = render(<BottomTabBar />);
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('is hidden on dashboard sub-pages', () => {
+      vi.mocked(usePathname).mockReturnValue('/dashboard/projects');
+      const { container } = render(<BottomTabBar />);
+
+      expect(container.firstChild).toBeNull();
     });
   });
 });

--- a/components/BottomTabBar.tsx
+++ b/components/BottomTabBar.tsx
@@ -2,6 +2,8 @@
 
 import { usePathname } from 'next/navigation';
 import Link from 'next/link';
+import { useAuth } from '@/providers/AuthProvider';
+import { isAuthEnabled } from '@/lib/config/featureFlags';
 
 interface TabItem {
   href: string;
@@ -58,7 +60,23 @@ const SamplerIcon = ({ active }: { active: boolean }) => (
   </svg>
 );
 
-const tabs: TabItem[] = [
+const AccountIcon = ({ active }: { active: boolean }) => (
+  <svg
+    className={`h-6 w-6 ${active ? 'text-black' : 'text-gray-500'}`}
+    fill={active ? 'currentColor' : 'none'}
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={active ? 0 : 2}
+      d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+    />
+  </svg>
+);
+
+const baseTabs: TabItem[] = [
   {
     href: '/',
     label: 'Home',
@@ -81,10 +99,26 @@ const tabs: TabItem[] = [
 
 export function BottomTabBar() {
   const pathname = usePathname();
+  const { user } = useAuth();
 
-  // Hide on premium page and other special pages
-  if (pathname === '/premium' || pathname?.startsWith('/blog')) {
+  // Hide on premium page, blog pages, and dashboard pages (dashboard has its own nav)
+  if (
+    pathname === '/premium' ||
+    pathname?.startsWith('/blog') ||
+    pathname?.startsWith('/dashboard')
+  ) {
     return null;
+  }
+
+  // Build tabs array - add Account tab if user is logged in and auth is enabled
+  const tabs: TabItem[] = [...baseTabs];
+  if (isAuthEnabled && user) {
+    tabs.push({
+      href: '/dashboard',
+      label: 'Account',
+      icon: <AccountIcon active={false} />,
+      matchPaths: ['/dashboard', '/dashboard/projects', '/dashboard/settings'],
+    });
   }
 
   const isActive = (tab: TabItem) => {
@@ -115,6 +149,7 @@ export function BottomTabBar() {
               {tab.href === '/' && <HomeIcon active={active} />}
               {tab.href === '/bleep' && <BleepIcon active={active} />}
               {tab.href === '/sampler' && <SamplerIcon active={active} />}
+              {tab.href === '/dashboard' && <AccountIcon active={active} />}
               <span
                 className={`text-xs font-medium ${active ? 'font-semibold text-black' : 'text-gray-500'}`}
               >


### PR DESCRIPTION
## Summary

Adds an Account tab to the mobile bottom navigation bar for logged-in users when auth is enabled, providing quick access to the dashboard.

## Changes

- **AccountIcon component**: New user profile icon matching existing icon style
- **Conditional Account tab**: Shows "Account" tab linking to `/dashboard` when `isAuthEnabled && user`
- **Dashboard page hiding**: BottomTabBar is now hidden on `/dashboard/*` pages (which have their own navigation)
- **Tests**: Added tests for Account tab behavior and dashboard page hiding

## Technical Details

- Uses `useAuth` hook to check if user is logged in
- Uses `isAuthEnabled` feature flag to gate the Account tab
- Tab is dynamically added to `baseTabs` array when conditions are met
- Icon follows existing active/inactive styling pattern

## Test plan
- [ ] Verify Account tab appears in BottomTabBar when logged in (with `NEXT_PUBLIC_AUTH_ENABLED=true`)
- [ ] Verify Account tab does not appear when logged out
- [ ] Verify Account tab does not appear when auth is disabled
- [ ] Verify Account tab links to /dashboard
- [ ] Verify BottomTabBar is hidden on /dashboard and /dashboard/* pages
- [ ] All tests pass (`npm test`)
- [ ] Type check passes (`npm run typecheck`)