### PR TITLE
chore: remove Doppler references and refresh CLAUDE.md

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,24 +1,20 @@
 # ============================================
-# SECRETS MANAGEMENT: DOPPLER
+# SECRETS MANAGEMENT: VERCEL
 # ============================================
-# This project uses Doppler for secrets management.
-# DO NOT create a .env.local file - use Doppler instead.
+# Environment variables for this project live in Vercel.
+# Pull them locally after linking the project:
 #
-# Setup:
-#   1. Install Doppler CLI: brew install dopplerhq/cli/doppler
-#   2. Login: doppler login
-#   3. Configure: doppler setup (select bleep-that-sht / dev)
+#   1. Install Vercel CLI: npm i -g vercel@latest
+#   2. Link the project:   vercel link
+#   3. Pull env vars:      vercel env pull .env.local
 #
-# Run dev server with Doppler:
-#   doppler run -- npm run dev
-#
-# Or use the npm script:
-#   npm run dev:doppler
+# Then run the dev server normally:
+#   npm run dev
 #
 # ============================================
 # ENVIRONMENT VARIABLES REFERENCE
 # ============================================
-# These are managed in Doppler, listed here for reference only.
+# These are managed in Vercel — listed here for reference only.
 
 # Supabase Configuration
 # NEXT_PUBLIC_SUPABASE_URL=https://xxx.supabase.co

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,7 +209,7 @@ Playwright starts `npm run dev` locally and `npm run start` in CI.
 
 ## Code Quality & Standards
 
-- **ESLint** via legacy `.eslintrc.json` config with Next.js + TypeScript + Prettier integration. The lint scripts set `ESLINT_USE_FLAT_CONFIG=false` to opt *out* of ESLint 9's flat-config default and keep the eslintrc loader. If you migrate to `eslint.config.js` later, remove that env var from the scripts.
+- **ESLint** via legacy `.eslintrc.json` config with Next.js + TypeScript + Prettier integration. The lint scripts set `ESLINT_USE_FLAT_CONFIG=false` to opt _out_ of ESLint 9's flat-config default and keep the eslintrc loader. If you migrate to `eslint.config.js` later, remove that env var from the scripts.
 - **Prettier** with Tailwind class sorting (`prettier-plugin-tailwindcss`)
 - **Knip** runs in CI and pre-push to catch unused code and exports
 - TypeScript strict enough to gate the build (`npm run typecheck` in CI)
@@ -228,6 +228,7 @@ Playwright starts `npm run dev` locally and `npm run start` in CI.
 ## Routes
 
 **Marketing / public:**
+
 - `/` — Home
 - `/bleep` — Client-side bleeping interface
 - `/sampler` — Transcription model comparison
@@ -235,10 +236,12 @@ Playwright starts `npm run dev` locally and `npm run start` in CI.
 - `/for-educators`, `/premium` — Landing pages
 
 **Auth (feature-flagged):**
+
 - `/auth/login`, `/auth/signup`, `/auth/reset-password`, `/auth/update-password`
 - `/auth/callback` — Supabase OAuth callback (outside the `(auth)` route group, so middleware treats it as public)
 
 **Authenticated dashboard:**
+
 - `/dashboard`
 - `/dashboard/projects`
 - `/dashboard/projects/[id]`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,183 +4,244 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Bleep That Sh\*t! is a Next.js application for in-browser audio and video censorship. It processes media files entirely client-side using WebAssembly and Web Workers, ensuring user privacy.
+Bleep That Sh\*t! is a Next.js application for audio and video censorship. Users upload media, the app transcribes it with word-level timestamps, and replaces selected words with bleeps.
+
+The app runs **two processing pipelines side-by-side**:
+
+1. **Client-side (free / anonymous path)** — Whisper ONNX in Web Workers + FFmpeg.wasm in the browser. No server involvement, fully private.
+2. **Cloud (authenticated path)** — files upload to Supabase Storage, jobs get enqueued to a Postgres message queue (PGMQ), and a Supabase Edge Function pulls them and calls Groq's transcription API. Results write back to Postgres and surface in the user's dashboard.
+
+The cloud path is gated by auth and subscription tier (Stripe).
 
 ## Tech Stack
 
-- **Framework**: Next.js 15 with React 19
-- **Styling**: Tailwind CSS
-- **Client-Side Processing**: Web Workers for heavy computation
-- **Key Libraries**:
-  - `@huggingface/transformers` - Whisper ONNX models for transcription
-  - `@ffmpeg/ffmpeg` - WebAssembly-based media processing
-  - `plyr-react` - Media player
-  - `react-dropzone` - File uploads
-  - `dexie` - IndexedDB wrapper for caching
+- **Framework**: Next.js 15 (App Router) with React 19
+- **Styling**: Tailwind CSS v4
+- **Language**: TypeScript 5.9
+- **Secrets management**: Vercel env vars (pulled locally via `vercel env pull .env.local`)
+
+**Backend / integrations:**
+
+- **Supabase** (`@supabase/ssr`, `@supabase/supabase-js`) — auth, Postgres, Storage, Edge Functions
+- **PGMQ** — Postgres-native message queue for transcription jobs (extension + migration `00004_pgmq_queue.sql`)
+- **Groq** (`groq-sdk`) — cloud transcription provider (Whisper-class models)
+- **Stripe** — subscriptions (Starter / Pro / Team tiers), Checkout, Billing Portal, webhooks
+
+**Client-side processing (original path):**
+
+- `@huggingface/transformers` — Whisper ONNX models running in Web Workers
+- `@ffmpeg/ffmpeg` + `@ffmpeg/core` — WebAssembly audio extraction & remuxing
+- `plyr-react` — media player
+- `react-dropzone` — file uploads
+- `dexie` — IndexedDB wrapper for model/asset caching
+
+**Content / misc:**
+
+- `remark`, `rehype`, `gray-matter` — markdown pipeline for blog posts in `content/blog/`
+- `file-type` — MIME sniffing for uploaded files
 
 ## Architecture
 
-### Client-Side Processing Pipeline
+### Directory layout
 
-1. **File Upload**: Users upload MP3/MP4 files via react-dropzone
-2. **Audio Extraction**: FFmpeg.wasm extracts audio from video files
-3. **Transcription**: Whisper ONNX models run in Web Workers to generate word-level timestamps
-4. **Censoring**: Web Audio API processes audio to insert bleeps at specified timestamps
-5. **Remuxing**: FFmpeg.wasm combines censored audio with original video
+```
+app/                      Next.js App Router
+  (auth)/auth/            Login, signup, reset-password, update-password (route group)
+  (dashboard)/dashboard/  Authenticated dashboard, projects list, /projects/[id]
+  auth/callback/          Supabase OAuth callback handler (outside the (auth) group)
+  api/                    API route handlers (see below)
+  workers/                Web Workers: transcription, transcriptionSampler, remux
+  bleep/                  Main in-browser censoring interface
+  sampler/                Transcription model comparison tool
+  blog/                   Blog listing + post pages
+  for-educators/          Marketing landing
+  premium/                Subscription upsell page
 
-### Project Structure
+components/               React components (Navbar, Footer, feature components)
+providers/                React context providers (AuthProvider)
+hooks/                    Custom hooks (useProject, useProjects, useJobStatus, useUsage, useFileUpload)
+lib/
+  supabase/               client.ts, server.ts, storage.ts — SSR + browser Supabase clients
+  stripe/                 config.ts — price IDs, tier definitions
+  groq/                   service.ts — Groq SDK wrapper
+  usage/                  Subscription usage tracking
+  blog/                   Markdown post loading / parsing
+  constants/              externalLinks, structuredData
+  utils/                  audio processing, paths, caching (client-side pipeline helpers)
+  config/, types/         Shared config + TS types
+types/supabase.ts         Generated Supabase types
 
-- `app/` - Next.js pages and routes
-  - `app/bleep/page.tsx` - Main bleeping interface
-  - `app/sampler/page.tsx` - Model comparison tool
-  - `app/workers/` - Web Workers for heavy processing (transcription, remuxing)
-- `components/` - React components (Navbar, Footer)
-- `lib/utils/` - Utility functions (audio processing, caching, paths)
-- `tests/` - Playwright E2E tests
-- `public/` - Static assets
+supabase/
+  migrations/             6 SQL migrations (schema, storage buckets, jobs, PGMQ, subscription events)
+  functions/
+    process-transcription/  Edge Function: pulls jobs from PGMQ, calls Groq, writes results
+
+middleware.ts             Auth routing (guards /dashboard, redirects authed users away from /auth/*);
+                          feature-flagged via NEXT_PUBLIC_AUTH_ENABLED
+
+content/blog/             Markdown blog posts
+docs/plans/               auth-ux-plan.md, payment-plan.md
+plans/                    Strategic planning docs
+scripts/                  pre-push.sh, test-groq.ts, test-cloud-e2e.ts
+tests/                    Playwright + Vitest test suites (see Testing)
+demos/                    Standalone Playwright demo/showcase scripts
+```
+
+### API routes (`app/api/`)
+
+- `POST /api/process/start` — enqueue a transcription job onto PGMQ
+- `POST /api/transcribe/cloud` — direct Groq transcription endpoint (synchronous path)
+- `GET|POST /api/projects` — list/create user projects
+- `GET|PUT|DELETE /api/projects/[id]` — single project CRUD
+- `GET /api/projects/[id]/jobs` — list jobs for a project
+- `GET /api/jobs/[id]` — job status/result
+- `GET /api/wordsets` — user's saved wordsets
+- `POST /api/checkout` — create Stripe Checkout Session
+- `POST /api/billing-portal` — create Stripe Billing Portal Session
+- `POST /api/webhooks/stripe` — Stripe webhook receiver (subscription lifecycle)
+
+### Auth
+
+- Supabase Auth (email/password). `providers/AuthProvider.tsx` exposes context app-wide.
+- `middleware.ts` checks for Supabase auth-token cookies and guards `(dashboard)` routes.
+- Entire auth system is behind `NEXT_PUBLIC_AUTH_ENABLED` — when false, middleware short-circuits and `/auth/*` routes redirect to home.
 
 ## Development Commands
 
 ```bash
-# Install dependencies
+# Install
 npm install
 
-# Development server
-npm run dev                       # Start Next.js dev server
+# Dev server (port 3004 — reads from .env.local)
+npm run dev
 
-# Run tests
-npm test                          # Run unit tests with Vitest
-npm run test:unit                 # Run unit tests (same as npm test)
-npm run test:unit:watch           # Run unit tests in watch mode
-npm run test:unit:ui              # Run unit tests with Vitest UI
-npm run test:unit:coverage        # Run unit tests with coverage report
-npm run test:e2e                  # E2E tests with Playwright
-npm run test:e2e:ui               # E2E tests with Playwright UI
-npm run test:e2e:debug            # Debug E2E tests
+# Unit tests (Vitest)
+npm test                          # same as test:unit
+npm run test:unit:watch
+npm run test:unit:ui
+npm run test:unit:coverage
 
-# Linting and code quality
-npm run lint                      # Run ESLint
-npm run lint:fix                  # Auto-fix ESLint issues
-npm run format                    # Format code with Prettier
-npm run format:check              # Check formatting without changes
-npm run typecheck                 # Run TypeScript compiler check
+# Playwright — multiple suites
+npm run test:smoke                # fast UI smoke tests (smoke-chromium project)
+npm run test:e2e                  # full workflow tests (e2e project)
+npm run test:all:playwright       # runs every Playwright project
+npm run test:setup:fixtures       # regenerate test fixture data
 
-# Build for production
-npm run build                     # Build Next.js application
-npm run export                    # Export static site
+# Code quality
+npm run lint
+npm run lint:fix
+npm run format
+npm run format:check
+npm run typecheck
+npm run knip                      # dead code / unused exports
+
+# Full local CI equivalent
+npm run pre-push                  # lint + format + typecheck + knip + unit + smoke + build
+npm run pre-push:quick            # same, skip smoke tests
+npm run validate                  # same steps, different entrypoint
+
+# Build
+npm run build
 ```
 
-## Testing Strategy
+Port `3004` (not the default 3000) — Playwright's `baseURL` is pinned to it.
 
-### Unit Tests (Vitest)
+## Testing
 
-Unit tests are configured with Vitest and test utility functions and React components:
+### Unit tests (Vitest)
 
-**Test Files:**
+- Config: `vitest.config.ts` — jsdom environment, global mocks in `tests/setup.ts`
+- Unit test files live next to source (`*.test.ts` / `*.test.tsx`) under `lib/` and `components/`
+- Coverage thresholds configured in `vitest.config.ts` (currently ~18–20%)
+- Vitest **excludes** `tests/**/*.spec.ts` — those are Playwright
 
-- `lib/utils/paths.test.ts` - Path resolution logic (5 tests)
-- `lib/utils/audioProcessor.test.ts` - Audio processing and WAV encoding (10 tests)
-- `lib/utils/audioDecode.test.ts` - Audio decoding and resampling (8 tests)
-- `components/Navbar.test.tsx` - Navigation component rendering (5 tests)
-- `components/Footer.test.tsx` - Footer component rendering (7 tests)
+### Playwright (`tests/`)
 
-**Coverage:**
+Playwright config defines multiple projects, each with its own timeouts and file patterns:
 
-- ✅ 35 unit tests covering utility functions and React components
-- ✅ Mock browser APIs (AudioContext, OfflineAudioContext, File, Blob)
-- ✅ Test configuration in `vitest.config.ts`
-- ✅ Test setup with global mocks in `tests/setup.ts`
+- **`smoke-chromium`** — fast smoke tests (`tests/smoke/*.spec.ts`), 10s action / 30s nav timeouts
+- **`e2e`** — full workflow tests (`tests/e2e/**/*.spec.ts`), 3-minute timeout
+- **Legacy browser projects** (`chromium`, `firefox`, `webkit`, `Mobile Chrome`, `Mobile Safari`) — excluded from smoke/e2e patterns
 
-**What's NOT unit tested:**
+Test directory structure:
 
-- Worker code (tested via E2E tests)
-- Complex audio processing functions (`applyBleeps`, `applyBleepsToVideo`) - tested via E2E
-- Page components (`app/**`) - tested via E2E
+```
+tests/
+  smoke/          Fast UI smoke tests (navigation, home, file upload, responsive, etc.)
+  e2e/            Full workflow tests (mobile nav, SEO, tab transitions, transcription, file validation, wordlists)
+  integration/    transcription-lengths.spec.ts
+  regression/     chunk-merging.spec.ts
+  helpers/        Page objects, network mocks, file/wait helpers
+  setup/          generate-test-fixtures.ts
+  fixtures/       transcripts/, files/
+  archived/       Deprecated older suites
+```
 
-### E2E Tests (Playwright)
+Playwright starts `npm run dev` locally and `npm run start` in CI.
 
-- **E2E Tests**: 16 Playwright test files in `tests/` directory covering full user workflows
-- Test frameworks: Vitest (unit tests), Playwright (E2E tests)
+### pre-push script
+
+`scripts/pre-push.sh` runs the same checks CI runs — use it locally before pushing to catch failures early.
+
+## CI / Deployment
+
+### GitHub Actions (`.github/workflows/`)
+
+- **`ci.yml`** — runs on PRs and pushes to `main`:
+  1. ESLint
+  2. Prettier format check
+  3. TypeScript typecheck
+  4. Knip (unused code / exports)
+  5. Unit tests + coverage
+  6. Next.js build
+  7. Smoke tests (single job)
+  8. E2E tests (sharded across 3 parallel jobs: `--shard=1/3`, `2/3`, `3/3`)
+
+- **`deploy-production.yml`** — Vercel production deploy, triggered on `release: published`. Uses the Vercel CLI with `VERCEL_TOKEN` / `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID` secrets.
+
+- **`link-check.yml`** — external link validation.
+
+### Deployment target: Vercel
+
+`next.config.ts` is a **standard Next.js server build** — images unoptimized (for WASM compatibility), no static export. Preview deployments are handled by Vercel's default PR preview behavior; production deploys happen on release.
+
+> The old CLAUDE.md mentioned GitHub Pages. That is no longer accurate — the app runs on Vercel.
 
 ## Code Quality & Standards
 
-### Linting
-
-- **ESLint**: Configured with Next.js, TypeScript, and Prettier integration
-- **Prettier**: Auto-formatting with Tailwind CSS class sorting
-- **Rules**:
-  - `console` statements: warnings (for debugging, should be removed in production)
-  - TypeScript `any`: warnings (gradually tighten)
-  - Unused variables: warnings (with `_` prefix exemption)
-  - React hooks: enforced dependency arrays
-
-### Formatting Standards
-
-- Single quotes for strings
-- 2-space indentation
-- Semicolons required
-- Max line length: 100 characters
-- Trailing commas: ES5 style
-- Arrow function parentheses: avoid when possible
-
-### Running Linting
-
-```bash
-# Check for issues
-npm run lint
-
-# Auto-fix issues
-npm run lint:fix
-
-# Format all files
-npm run format
-
-# Check formatting
-npm run format:check
-
-# Type check
-npm run typecheck
-```
-
-## Continuous Integration
-
-### GitHub Actions CI
-
-The repository includes automated CI checks via GitHub Actions (`.github/workflows/ci.yml`):
-
-**Triggers:**
-
-- Pull requests to `main` branch
-- Pushes to `main` branch
-
-**CI Pipeline Steps:**
-
-1. **ESLint** - Code quality and style checks
-2. **Prettier** - Code formatting verification
-3. **TypeScript** - Type checking across the codebase
-4. **Unit Tests** - Vitest test suite (35 tests)
-5. **Build** - Next.js production build verification
-
-**Status:** All checks must pass before merging PRs.
-
-**Other Workflows:**
-
-- `deploy.yml` - Deploys to GitHub Pages on main branch pushes
-- `test-build.yml` - Legacy build test (superseded by CI workflow)
+- **ESLint** via legacy `.eslintrc.json` config with Next.js + TypeScript + Prettier integration. The lint scripts set `ESLINT_USE_FLAT_CONFIG=false` to opt *out* of ESLint 9's flat-config default and keep the eslintrc loader. If you migrate to `eslint.config.js` later, remove that env var from the scripts.
+- **Prettier** with Tailwind class sorting (`prettier-plugin-tailwindcss`)
+- **Knip** runs in CI and pre-push to catch unused code and exports
+- TypeScript strict enough to gate the build (`npm run typecheck` in CI)
+- Format: single quotes, 2-space indent, semicolons, 100-char line limit, ES5 trailing commas
 
 ## Important Considerations
 
-1. **Client-Side Processing**: Core functionality runs in the browser. Server is minimal by design.
-2. **Web Workers**: Heavy processing happens in workers to keep UI responsive
-3. **CORS Configuration**: FFmpeg core files must be served with proper CORS headers
-4. **Memory Management**: Large files are processed in chunks to avoid memory issues
-5. **Browser Compatibility**: Requires modern browsers with WebAssembly and Web Workers support
+1. **Two pipelines, two threat models.** The client-side pipeline keeps user media fully in-browser and never touches a server. The cloud pipeline uploads to Supabase Storage and sends audio to Groq. Be careful not to blur this boundary — features added to one path don't automatically belong in the other.
+2. **Env vars live in Vercel.** Run `vercel link` once, then `vercel env pull .env.local` to hydrate your local environment. `npm run dev` reads from `.env.local`.
+3. **Web Workers still matter.** The client-side pipeline's responsiveness depends on workers in `app/workers/` staying off the main thread.
+4. **CORS / WASM.** FFmpeg core files still need COOP/COEP headers. Don't break them.
+5. **Auth is feature-flagged.** `NEXT_PUBLIC_AUTH_ENABLED` toggles the entire auth system. Middleware, route groups, and UI all respect it.
+6. **Port 3004.** Dev server and Playwright baseURL are pinned there — not 3000.
+7. **Supabase Edge Function auth.** `process-transcription` handles its own auth; changes to deployment commands should preserve whatever JWT verification posture it currently expects.
 
 ## Routes
 
-- `/` - Home page
-- `/bleep` - Main bleeping interface (transcription + censoring)
-- `/sampler` - Model comparison tool
+**Marketing / public:**
+- `/` — Home
+- `/bleep` — Client-side bleeping interface
+- `/sampler` — Transcription model comparison
+- `/blog`, `/blog/[slug]` — Blog
+- `/for-educators`, `/premium` — Landing pages
+
+**Auth (feature-flagged):**
+- `/auth/login`, `/auth/signup`, `/auth/reset-password`, `/auth/update-password`
+- `/auth/callback` — Supabase OAuth callback (outside the `(auth)` route group, so middleware treats it as public)
+
+**Authenticated dashboard:**
+- `/dashboard`
+- `/dashboard/projects`
+- `/dashboard/projects/[id]`
 
 ## Social Starter Pack Tools
 
@@ -191,11 +252,8 @@ Keyword suggestions from Google, YouTube, Bing, Amazon, and DuckDuckGo.
 - README: https://github.com/neonwatty/autocomplete-cli
 
 ```bash
-# Basic usage
 autocomplete google "topic"
 autocomplete youtube "topic"
-
-# Get help
 autocomplete --help
 ```
 
@@ -206,27 +264,18 @@ Search Reddit for pain points and market opportunities.
 - README: https://github.com/neonwatty/reddit-market-research
 
 ```bash
-# Search a subreddit with keywords
 make reddit ARGS='search -s "subreddit" -k "keywords"'
-
-# Setup (required for credentials)
 make doppler-connect
-
-# Get help
 reddit-market-research --help
 ```
 
 ### demo-recorder
 
-Record demo videos and screenshots of web apps.
+Record demo videos and screenshots of web apps. Requires FFmpeg installed.
 
 - README: https://github.com/neonwatty/demo-recorder
-- Requires: FFmpeg installed
 
 ```bash
-# Record a demo video
 demo-recorder record demo.ts -o video.mp4
-
-# Get help
 demo-recorder --help
 ```

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "0.4.0",
   "private": true,
   "scripts": {
-    "dev": "doppler run -- next dev -p 3004",
-    "dev:local": "next dev -p 3004",
+    "dev": "next dev -p 3004",
     "build": "next build",
     "start": "next start",
     "test": "vitest run",

--- a/scripts/test-cloud-e2e.ts
+++ b/scripts/test-cloud-e2e.ts
@@ -10,9 +10,10 @@
  * 6. Verifies results in database
  *
  * Usage:
- *   doppler run -- npx tsx scripts/test-cloud-e2e.ts
+ *   # First ensure .env.local is populated: `vercel env pull .env.local`
+ *   set -a && source .env.local && set +a && npx tsx scripts/test-cloud-e2e.ts
  *
- * Environment vars (via Doppler):
+ * Environment vars (from .env.local):
  *   NEXT_PUBLIC_SUPABASE_URL
  *   SUPABASE_SERVICE_ROLE_KEY
  */
@@ -35,7 +36,10 @@ async function main() {
     console.error('❌ Missing required environment variables');
     console.error('   NEXT_PUBLIC_SUPABASE_URL:', supabaseUrl ? '✓' : '✗');
     console.error('   SUPABASE_SERVICE_ROLE_KEY:', serviceRoleKey ? '✓' : '✗');
-    console.error('\n   Run with: doppler run -- npx tsx scripts/test-cloud-e2e.ts');
+    console.error(
+      '\n   Run with: set -a && source .env.local && set +a && npx tsx scripts/test-cloud-e2e.ts'
+    );
+    console.error('   (First populate .env.local via: vercel env pull .env.local)');
     process.exit(1);
   }
 


### PR DESCRIPTION
## Summary

- Consolidates the dev workflow around **Vercel env vars only** (pulled locally via `vercel env pull .env.local`), dropping stale Doppler config that wasn't in active use.
- Captures the in-progress CLAUDE.md architecture refresh documenting the two-pipeline design (client-side Whisper + cloud Groq via Supabase Edge Function).
- Collapses `npm run dev` + `npm run dev:local` into a single `dev` script, since there's no longer a Doppler variant to differentiate from.

## Why

Doppler was wired in during Phase 3 cloud work (commit f5db00d) but never became part of the actual day-to-day workflow. The written config (package.json dev script, .env.local.example, CLAUDE.md) drifted out of sync with what's actually used. This PR re-aligns the tree with reality so future contributors (and Claude sessions) don't waste time installing Doppler for a workflow that doesn't need it.

One intentional Doppler reference remains in CLAUDE.md under the reddit-market-research social-starter-pack section — that's for a separate external CLI's own secrets, not this project.

## Files changed

- ``package.json`` — `dev` now runs `next dev -p 3004` directly; `dev:local` removed as redundant
- ``CLAUDE.md`` — secrets-management line, dev-commands block, and "Important Considerations" item all updated to document the Vercel env-pull workflow
- ``.env.local.example`` — top block rewritten to document `vercel link` → `vercel env pull .env.local` → `npm run dev`
- ``scripts/test-cloud-e2e.ts`` — usage comment + error message updated to reference loading .env.local instead of `doppler run --`

## Test plan

- [ ] CI green (lint + format + typecheck + knip + unit + smoke + build)
- [ ] `npm run dev` starts the dev server on port 3004 without invoking any Doppler binary
- [ ] `grep -rn doppler` on the repo returns only the intentional reddit-market-research line in CLAUDE.md (plus any ongoing planning docs, which are out of scope)