### PR TITLE
chore: migrate stale bleep-that-sht.com references to bleepthat.sh

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,7 +23,7 @@ const merriweather = Merriweather({
 
 // Get base path for production
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
-const siteUrl = 'https://bleep-that-sht.com';
+const siteUrl = 'https://bleepthat.sh';
 
 export const viewport: Viewport = {
   width: 'device-width',

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,7 +1,7 @@
 import { MetadataRoute } from 'next';
 import { getAllPosts } from '@/lib/blog/posts';
 
-const SITE_URL = 'https://bleep-that-sht.com';
+const SITE_URL = 'https://bleepthat.sh';
 
 export default function sitemap(): MetadataRoute.Sitemap {
   // Static pages with their priorities and change frequencies

--- a/lib/constants/structuredData.ts
+++ b/lib/constants/structuredData.ts
@@ -1,4 +1,4 @@
-export const SITE_URL = 'https://bleep-that-sht.com';
+export const SITE_URL = 'https://bleepthat.sh';
 export const SITE_NAME = 'Bleep That Sh*t!';
 
 export const organizationSchema = {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://bleep-that-sht.com/sitemap.xml
+Sitemap: https://bleepthat.sh/sitemap.xml

--- a/tests/e2e/seo.spec.ts
+++ b/tests/e2e/seo.spec.ts
@@ -10,7 +10,7 @@
 
 import { test, expect } from './e2e-setup';
 
-const SITE_URL = 'https://bleep-that-sht.com';
+const SITE_URL = 'https://bleepthat.sh';
 
 test.describe('SEO - Home Page', () => {
   test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
## Summary

Aligns all canonical URL / sitemap metadata with the actual production domain **`bleepthat.sh`**. The legacy domain `bleep-that-sht.com` still exists as a 301 alias (verified via `curl -sI -L https://bleep-that-sht.com` → lands at `https://bleepthat.sh/`), but the code had it hardcoded as the canonical across OG tags, JSON-LD, sitemap, and `robots.txt`.

## Why

Right now the app:

- **Serves** from `bleepthat.sh`
- But **tells** Google / social networks / Meta that canonical is `bleep-that-sht.com`

That's an active SEO/social-card misconfiguration. OG share cards show the legacy URL; Google Search Console signals point at the wrong property; Meta's domain verification (which is being set up separately for the upcoming Meta Pixel work) would mismatch the canonical in structured data.

## What changed

5 files, simple find/replace (`bleep-that-sht.com` → `bleepthat.sh`), no logic changes:

- `app/layout.tsx:26` — `siteUrl` / `metadataBase` (drives all Next.js OG tags + canonical URLs)
- `app/sitemap.ts:4` — `SITE_URL` for sitemap generation
- `lib/constants/structuredData.ts:1` — `SITE_URL` used by JSON-LD schemas (Organization, WebSite, WebApplication, HowTo)
- `public/robots.txt:4` — Sitemap declaration for crawlers
- `tests/e2e/seo.spec.ts:13` — test constant kept in sync with app so SEO canonical assertion still passes

`lib/analytics.ts:35` comment referring to `GA4 (bleep-that-sht)` is **left alone** — that's a GA4 property label, not a URL.

## Test plan

- [ ] CI green (lint + format + typecheck + knip + unit + smoke + build)
- [ ] SEO e2e test passes with updated canonical assertion (`tests/e2e/seo.spec.ts`)
- [ ] After deploy, verify OG share card uses `bleepthat.sh` (paste `https://bleepthat.sh/` into the [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/))
- [ ] After deploy, `curl https://bleepthat.sh/sitemap.xml` shows all URLs with the new domain
- [ ] After deploy, `curl https://bleepthat.sh/robots.txt` shows the updated Sitemap line

## Independent of

This PR is independent of #142 (Doppler cleanup) and the upcoming Meta Pixel + Conversions API PR. It can ship in any order relative to those.