### PR TITLE
feat(meta): add Conversions API server wrapper (Phase 1)

### DIFF
--- a/docs/plans/meta-pixel-plan.md
+++ b/docs/plans/meta-pixel-plan.md
@@ -58,11 +58,11 @@ for a separate CLI tool's own secrets management, not this project's config.
 
 ## Environment variables
 
-| Variable | Scope | Notes |
-|---|---|---|
-| `NEXT_PUBLIC_META_PIXEL_ID` | Browser + server | `NEXT_PUBLIC_` prefix is required so the Pixel script can read it at runtime |
-| `META_CAPI_ACCESS_TOKEN` | Server only | Secret — never expose to browser |
-| `META_TEST_EVENT_CODE` | Server only | Set in dev/staging, unset (or empty) in prod. Enables Meta Events Manager → Test Events tab routing |
+| Variable                    | Scope            | Notes                                                                                               |
+| --------------------------- | ---------------- | --------------------------------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_META_PIXEL_ID` | Browser + server | `NEXT_PUBLIC_` prefix is required so the Pixel script can read it at runtime                        |
+| `META_CAPI_ACCESS_TOKEN`    | Server only      | Secret — never expose to browser                                                                    |
+| `META_TEST_EVENT_CODE`      | Server only      | Set in dev/staging, unset (or empty) in prod. Enables Meta Events Manager → Test Events tab routing |
 
 ## Files to create
 
@@ -132,9 +132,33 @@ EU country code constant + `GB`. Used by middleware geo check.
 ```ts
 export const CONSENT_REQUIRED_COUNTRIES = new Set([
   // EU member states
-  'AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'FI', 'FR',
-  'DE', 'GR', 'HU', 'IE', 'IT', 'LV', 'LT', 'LU', 'MT', 'NL',
-  'PL', 'PT', 'RO', 'SK', 'SI', 'ES', 'SE',
+  'AT',
+  'BE',
+  'BG',
+  'HR',
+  'CY',
+  'CZ',
+  'DK',
+  'EE',
+  'FI',
+  'FR',
+  'DE',
+  'GR',
+  'HU',
+  'IE',
+  'IT',
+  'LV',
+  'LT',
+  'LU',
+  'MT',
+  'NL',
+  'PL',
+  'PT',
+  'RO',
+  'SK',
+  'SI',
+  'ES',
+  'SE',
   // UK
   'GB',
 ]);
@@ -286,14 +310,14 @@ Verify Purchase appears in Meta Test Events with correct `value`, `currency`, an
 
 ## Effort estimate
 
-| Phase | Estimate |
-|---|---|
-| CAPI wrapper + hashing + unit tests | 1.5 hrs |
-| Pixel component + wrapper refactor + GA migration | 1 hr |
-| Consent banner + middleware geo logic | 1.5 hrs |
-| Event wiring (5 events across 4 files) | 1 hr |
-| Verification via Meta Test Events + Stripe CLI + Playwright assertion | 1 hr |
-| **Total** | **~6 hrs** |
+| Phase                                                                 | Estimate   |
+| --------------------------------------------------------------------- | ---------- |
+| CAPI wrapper + hashing + unit tests                                   | 1.5 hrs    |
+| Pixel component + wrapper refactor + GA migration                     | 1 hr       |
+| Consent banner + middleware geo logic                                 | 1.5 hrs    |
+| Event wiring (5 events across 4 files)                                | 1 hr       |
+| Verification via Meta Test Events + Stripe CLI + Playwright assertion | 1 hr       |
+| **Total**                                                             | **~6 hrs** |
 
 Add ~30 min buffer for field-name mismatches with the Meta CAPI spec (inevitable on first integration).
 

--- a/docs/plans/meta-pixel-plan.md
+++ b/docs/plans/meta-pixel-plan.md
@@ -1,0 +1,345 @@
+# Meta Pixel + Conversions API Implementation Plan
+
+Status: Draft for review. No code written yet.
+Date: 2026-04-15
+
+## Goal
+
+Install Meta Pixel (browser) + Conversions API (server) dual-send on
+bleep-that-shit to support a new Meta ads campaign. Track conversion funnel
+from marketing surfaces → signup → paid subscription.
+
+## Locked-in decisions (from user)
+
+1. **Dual-send architecture**: browser Pixel for client-side events, server-side
+   Conversions API (CAPI) for high-value events. Not browser-only.
+
+2. **Consent**: geo-gated via Vercel middleware. EU/UK visitors get a consent
+   banner that blocks the pixel until accepted. Everyone else fires freely.
+   Net-new — no consent banner exists today.
+
+3. **Scope: marketing-only wrapper refactor (option b)**. All trackers
+   (existing GA + Google Ads + new Meta Pixel) scoped to marketing surfaces
+   only: `/`, `/premium`, `/for-educators`, `/blog/*`, `/auth/*`. Processing
+   routes (`/bleep`, `/sampler`) and dashboard routes become tracker-free.
+   Requires moving `GoogleAnalytics` out of root layout into a conditional
+   wrapper. Matches the "100% private in-browser" marketing story for the
+   client-side pipeline.
+
+4. **Event taxonomy**:
+   | Event | Channel | Fire location |
+   |---|---|---|
+   | `PageView` | Browser pixel | Auto-fires on every marketing surface |
+   | `ViewContent` | Browser pixel | `/premium` page |
+   | `Lead` | Browser pixel | Signup page — submit click (tight signal for paid ads) |
+   | `CompleteRegistration` | CAPI only | `app/auth/callback/route.ts` (convergence point for email-confirm + OAuth — avoids counting unverified signups) |
+   | `Purchase` | CAPI only | `app/api/webhooks/stripe/route.ts` → `handleCheckoutCompleted`. Uses `session.metadata.supabase_user_id` for user matching. Value pulled from the Stripe Session (`amount_total / 100`), respects promo codes/discounts/currency. |
+
+5. **No bleep-completion event**. Revenue event (Purchase) matters more than
+   free-tier usage events for this campaign.
+
+## Secrets management: Vercel env vars
+
+The project uses **Vercel env vars only**. Day-to-day dev reads from a local
+`.env.local` pulled via `vercel env pull`.
+
+A separate cleanup (done 2026-04-15, in the same branch as this plan) removed
+stale Doppler references from `package.json`, `CLAUDE.md`, `.env.local.example`,
+and `scripts/test-cloud-e2e.ts`. One intentional Doppler reference remains in
+`CLAUDE.md` under the reddit-market-research external tool section — that's
+for a separate CLI tool's own secrets management, not this project's config.
+
+**For this feature**:
+
+1. Add the three Meta env vars in Vercel project settings (Production, Preview, Development scopes as appropriate — `META_TEST_EVENT_CODE` only in Preview/Development).
+2. Run `vercel env pull .env.local` locally to hydrate.
+3. Run `npm run dev` (port 3004).
+4. Link the project locally via `vercel link` if not already — there's no `.vercel/` directory in the repo today, so this is a prereq.
+
+## Environment variables
+
+| Variable | Scope | Notes |
+|---|---|---|
+| `NEXT_PUBLIC_META_PIXEL_ID` | Browser + server | `NEXT_PUBLIC_` prefix is required so the Pixel script can read it at runtime |
+| `META_CAPI_ACCESS_TOKEN` | Server only | Secret — never expose to browser |
+| `META_TEST_EVENT_CODE` | Server only | Set in dev/staging, unset (or empty) in prod. Enables Meta Events Manager → Test Events tab routing |
+
+## Files to create
+
+### `lib/meta/capi.ts`
+
+Server-side CAPI wrapper. Exports `sendMetaEvent({ eventName, eventTime, userData, customData, eventSourceUrl, eventId? })`.
+
+Responsibilities:
+
+- SHA-256 hash email/phone/name per Meta spec:
+  - Email: `sha256(email.trim().toLowerCase())`
+  - Phone: `sha256(digits_only_with_country_code)`
+  - First/last name: `sha256(name.trim().toLowerCase())`
+- Include `client_ip_address` and `client_user_agent` in `user_data` (from request headers where available) — improves match quality.
+- POST to `https://graph.facebook.com/v21.0/{PIXEL_ID}/events`.
+- Auth via `access_token` query param or bearer.
+- Include `test_event_code` in payload when env var is set.
+- Wrap fetch in try/catch — analytics failures must NEVER break the auth callback or Stripe webhook. Log and continue.
+- Return `{ ok: boolean, error?: string }` for observability; callers intentionally ignore.
+
+### `lib/meta/events.ts`
+
+Typed event builders layered on `capi.ts`:
+
+- `trackCompleteRegistration({ email, userId, ip, userAgent, eventSourceUrl })`
+- `trackPurchase({ email, userId, value, currency, eventId, ip, userAgent })`
+
+Keeps event-shape knowledge out of route handlers. Easier to unit test in isolation.
+
+### `components/MetaPixel.tsx`
+
+Mirrors `components/GoogleAnalytics.tsx` pattern exactly:
+
+- `next/script` with `strategy="afterInteractive"`.
+- Standard Meta Pixel init snippet + `fbq('track', 'PageView')`.
+- Reads `NEXT_PUBLIC_META_PIXEL_ID`; renders nothing if unset.
+- `<noscript>` fallback image for non-JS clients.
+
+### `components/MarketingTrackers.tsx`
+
+**Client component.** Central mount decision for ALL trackers.
+
+Logic:
+
+1. Read `usePathname()`.
+2. Check against marketing allowlist: `/`, `/premium`, `/for-educators`, paths starting with `/blog`, paths starting with `/auth` (but NOT `/auth/callback` which is server-only).
+3. Read `meta-consent-required` cookie (set by middleware based on geo).
+4. Read `meta-consent-granted` cookie (set by banner on accept).
+5. Mount `<GoogleAnalytics />` + `<MetaPixel />` only when: pathname is marketing-scoped AND (consent not required OR consent granted).
+6. Render `<CookieConsent />` only when consent is required and not yet granted.
+
+This is the **single source of truth** for whether any tracker loads — scattered conditional logic is anti-goal.
+
+### `components/CookieConsent.tsx`
+
+EU/UK consent banner.
+
+- Fixed-position bottom bar (least intrusive; standard pattern).
+- Accept: set `meta-consent-granted=1` cookie (1-year expiry), trigger re-render in parent wrapper so trackers mount.
+- Reject: set `meta-consent-granted=0` cookie (30-day expiry — avoids nagging on every page view).
+- Styling: match existing Navbar/Footer Tailwind conventions.
+
+### `lib/constants/geo.ts`
+
+EU country code constant + `GB`. Used by middleware geo check.
+
+```ts
+export const CONSENT_REQUIRED_COUNTRIES = new Set([
+  // EU member states
+  'AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'FI', 'FR',
+  'DE', 'GR', 'HU', 'IE', 'IT', 'LV', 'LT', 'LU', 'MT', 'NL',
+  'PL', 'PT', 'RO', 'SK', 'SI', 'ES', 'SE',
+  // UK
+  'GB',
+]);
+```
+
+## Files to modify
+
+### `middleware.ts`
+
+Add geo detection alongside existing auth guard (no conflict).
+
+- Check `request.geo?.country` (Vercel-populated).
+- If in `CONSENT_REQUIRED_COUNTRIES`, set response cookie `meta-consent-required=1` (session cookie or 1-day).
+- Else ensure cookie is cleared/not set.
+- `request.geo` is undefined in local `next dev` — wrapper must handle the `undefined` case gracefully (default: consent not required locally unless a dev override cookie is set).
+
+### `app/layout.tsx`
+
+- Remove `<GoogleAnalytics />` from root.
+- Replace with `<MarketingTrackers />`.
+- That's the entire diff — smallest change, highest blast radius.
+
+### `lib/analytics.ts`
+
+Extend existing wrapper (currently wraps `window.gtag`):
+
+- Add `trackMetaEvent(name: string, params?: Record<string, unknown>)` — checks `window.fbq` exists, calls `fbq('track', name, params)`.
+- Add unified convenience helpers where both GA and Meta should fire: `trackLead()`, `trackViewContent(params)`.
+- Keep the existing GA API untouched for backward compatibility.
+
+### `app/premium/page.tsx` (or a small client island inside it)
+
+Fire `trackViewContent({ content_name: 'premium', content_category: 'subscription' })` on mount via `useEffect`.
+
+Check current component structure — if the page is a server component, add a small `<PremiumViewContentBeacon />` client child rather than converting the whole page.
+
+### `app/(auth)/auth/signup/page.tsx` or `components/auth/SignupForm.tsx`
+
+Fire `trackLead()` on form submit click (pre-submit). Rationale: submit click = tight intent signal for a paid ads campaign; first-focus inflates with bounced fills.
+
+### `app/auth/callback/route.ts`
+
+After successful session exchange and before the redirect:
+
+```ts
+try {
+  await trackCompleteRegistration({
+    email: user.email,
+    userId: user.id,
+    ip: request.headers.get('x-forwarded-for') ?? undefined,
+    userAgent: request.headers.get('user-agent') ?? undefined,
+    eventSourceUrl: request.url,
+  });
+} catch (err) {
+  console.error('[meta-capi] CompleteRegistration failed', err);
+}
+```
+
+Fires for both email-confirm AND OAuth paths — that's why this is the chosen hook point, per locked-in decision 4.
+
+### `app/api/webhooks/stripe/route.ts` → `handleCheckoutCompleted`
+
+After the existing profile/subscription update, before the handler returns:
+
+```ts
+try {
+  await trackPurchase({
+    email: session.customer_details?.email ?? undefined,
+    userId: session.metadata?.supabase_user_id,
+    value: (session.amount_total ?? 0) / 100,
+    currency: (session.currency ?? 'usd').toUpperCase(),
+    eventId: session.id, // natural idempotency on Stripe webhook retry
+    ip: request.headers.get('x-forwarded-for') ?? undefined,
+    userAgent: request.headers.get('user-agent') ?? undefined,
+  });
+} catch (err) {
+  console.error('[meta-capi] Purchase failed', err);
+}
+```
+
+Three details that matter:
+
+- **`amount_total` is in cents** — dividing by 100 respects promo codes, discounts, and currency conversion without a tier lookup.
+- **`event_id = session.id`** — gives dedup on Stripe webhook retries, and also sets up dedup if we ever add a browser-side Purchase event later.
+- **Email normalization inside `capi.ts`** — callers pass plain values, wrapper hashes. Impossible to forget.
+
+## Order of operations
+
+1. **Resolve secrets question** (user action: pick option 1 or 2 above).
+2. **Add env vars** to chosen location(s).
+3. **`lib/meta/capi.ts`** — pure function, easiest to unit test first.
+4. **`lib/meta/capi.test.ts`** — Vitest. Cover hashing correctness (known test vectors from Meta docs), payload shape, `test_event_code` passthrough, graceful failure on fetch rejection.
+5. **`lib/meta/events.ts`** — thin builders.
+6. **`components/MetaPixel.tsx`** — mirror GA component.
+7. **`lib/constants/geo.ts`** + **`middleware.ts`** geo-cookie logic.
+8. **`components/CookieConsent.tsx`** + **`components/MarketingTrackers.tsx`** — wrapper + banner pair.
+9. **`app/layout.tsx`** swap — root-level change, verify smoke tests still pass.
+10. **`lib/analytics.ts`** — extend with Meta helpers.
+11. **Event wiring** in this order:
+    1. ViewContent (`/premium`)
+    2. Lead (signup form)
+    3. CompleteRegistration (auth callback)
+    4. Purchase (Stripe webhook)
+12. **End-to-end verification** via Meta Test Events tool (see below).
+
+**Why this order**: wrapper refactor is done BEFORE events are wired, so the pixel's mount-only-where-it-should behavior is proven before we start firing anything.
+
+## Testing strategy
+
+### Meta Test Events tool
+
+- Events Manager → Data Sources → [Pixel] → Test Events tab.
+- Enter `META_TEST_EVENT_CODE` value.
+- Browser events (PageView / ViewContent / Lead) should appear within ~10s of firing in local dev.
+- CAPI events appear with a "Server" label — lets you visually distinguish channels.
+
+### Meta Pixel Helper (Chrome extension)
+
+- Load `/bleep` → expect zero Pixel events (marketing-only scope working).
+- Load `/premium` → expect PageView + ViewContent.
+- Load `/auth/signup` in EU-simulated session → expect zero events until consent accepted.
+
+### Stripe webhook testing
+
+```bash
+stripe listen --forward-to localhost:3004/api/webhooks/stripe
+stripe trigger checkout.session.completed
+```
+
+Verify Purchase appears in Meta Test Events with correct `value`, `currency`, and `event_id`.
+
+### Vitest units (`lib/meta/capi.test.ts`)
+
+- SHA-256 hashing of known email/phone test vectors (Meta spec samples).
+- `test_event_code` included when env set, omitted when not.
+- Graceful failure on fetch rejection (doesn't throw).
+
+### Playwright smoke
+
+- Extend existing `/premium` smoke test:
+  - Assert `script[src*="connect.facebook.net"]` is present when consent not required.
+  - Assert NO such script is present on `/bleep`.
+- Catches accidental unmounting in future refactors.
+
+### Geo-gate testing
+
+- Vercel preview deploy is the only realistic way to test `request.geo` — local `next dev` doesn't populate it.
+- For local, fake it via a cookie override (`meta-consent-required=1` manually) or a dev-only env flag like `NEXT_PUBLIC_FORCE_CONSENT_BANNER=1`.
+
+## Effort estimate
+
+| Phase | Estimate |
+|---|---|
+| CAPI wrapper + hashing + unit tests | 1.5 hrs |
+| Pixel component + wrapper refactor + GA migration | 1 hr |
+| Consent banner + middleware geo logic | 1.5 hrs |
+| Event wiring (5 events across 4 files) | 1 hr |
+| Verification via Meta Test Events + Stripe CLI + Playwright assertion | 1 hr |
+| **Total** | **~6 hrs** |
+
+Add ~30 min buffer for field-name mismatches with the Meta CAPI spec (inevitable on first integration).
+
+## Open items requiring user input before execution
+
+1. **Lead trigger point** — default: submit click (not first-focus). Tight signal for paid ads. User can override if they want wider funnel coverage.
+2. **Consent banner UX** — default: fixed-position bottom bar. Alternatives: blocking modal, inline banner. Bottom bar is standard and least intrusive.
+3. **Consent rejection persistence** — default: 30-day cookie. Avoids nagging on every page view. User can override to session-only or longer.
+4. **CookieConsent styling primitives** — match existing Navbar/Footer Tailwind, unless user has a preferred component library already in use. Need to scan `components/` during implementation to confirm.
+
+## Architectural notes for fresh-session analysis
+
+Three details that trip up most CAPI integrations, called out so a future session doesn't hit them:
+
+1. **Stripe amounts are in cents**. `amount_total: 999` = $9.99. Dividing by 100 respects the actual paid amount — promo codes, discounts, currency conversion — without a hardcoded tier lookup. Matches the locked-in "revenue from Session object" decision.
+
+2. **Email hashing normalization**. Meta spec: `sha256(email.trim().toLowerCase())`. Phone: `sha256(digits_only_with_country_code)`. Unnormalized values cause silent match-quality degradation, not an API error — easy to ship broken.
+
+3. **`event_id` for Purchase** = Stripe session ID. Two wins: (a) dedup on Stripe webhook retries; (b) if a browser-side Purchase event is ever added later, Meta auto-dedups across channels.
+
+One subtle architectural coupling worth flagging: **consent + scope + geo all collapse into a single mount decision** inside `<MarketingTrackers>`. Centralizing the boolean in one wrapper is what makes option (b) safer than it looks — the tracker-free guarantee on `/bleep` and `/sampler` comes from a single code path, not from scattered conditionals.
+
+## Files touched summary
+
+**Created (6):**
+
+- `lib/meta/capi.ts`
+- `lib/meta/events.ts`
+- `lib/meta/capi.test.ts`
+- `lib/constants/geo.ts`
+- `components/MetaPixel.tsx`
+- `components/MarketingTrackers.tsx`
+- `components/CookieConsent.tsx`
+
+**Modified (7):**
+
+- `middleware.ts`
+- `app/layout.tsx`
+- `lib/analytics.ts`
+- `app/premium/page.tsx` (or client island within)
+- `app/(auth)/auth/signup/page.tsx` or `components/auth/SignupForm.tsx`
+- `app/auth/callback/route.ts`
+- `app/api/webhooks/stripe/route.ts`
+
+**Env vars added:**
+
+- `NEXT_PUBLIC_META_PIXEL_ID`
+- `META_CAPI_ACCESS_TOKEN`
+- `META_TEST_EVENT_CODE`

--- a/lib/meta/capi.test.ts
+++ b/lib/meta/capi.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { hashEmail, hashPhone, hashName, sendMetaEvent } from './capi';
+
+// Meta Conversions API expects PII fields (email, phone, name) to be SHA-256 hashed
+// with specific normalization rules per their customer-information-parameters spec:
+// https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/customer-information-parameters
+//
+// Unhashed values are silently accepted but produce 0% match rate, which is invisible
+// unless you check the Events Manager diagnostics tab. Unit tests catch this.
+
+describe('hashEmail', () => {
+  it('matches Meta spec test vector for test@test.com', () => {
+    // This exact hash was observed in Meta's own Graph API Explorer sample payload
+    // during Pixel setup (2026-04-15). If this test fails, our hashing produces
+    // values that Meta will not match against its user database — all match
+    // rates will be zero and conversion tracking degrades silently.
+    const expected = 'f660ab912ec121d1b1e928a0bb4bc61b15f5ad44d5efdc4e1c92a25e99b8e44a';
+    expect(hashEmail('test@test.com')).toBe(expected);
+  });
+
+  it('normalizes case and whitespace before hashing', () => {
+    const canonical = hashEmail('test@test.com');
+    expect(hashEmail('TEST@TEST.COM')).toBe(canonical);
+    expect(hashEmail('Test@Test.COM')).toBe(canonical);
+    expect(hashEmail('  test@test.com  ')).toBe(canonical);
+    expect(hashEmail('\ttest@test.com\n')).toBe(canonical);
+  });
+
+  it('returns undefined for empty/missing input', () => {
+    expect(hashEmail(undefined)).toBeUndefined();
+    expect(hashEmail('')).toBeUndefined();
+    expect(hashEmail('   ')).toBeUndefined();
+  });
+});
+
+describe('hashPhone', () => {
+  it('strips non-digit characters before hashing', () => {
+    const canonical = hashPhone('5551234567');
+    expect(hashPhone('(555) 123-4567')).toBe(canonical);
+    expect(hashPhone('555-123-4567')).toBe(canonical);
+    expect(hashPhone('555.123.4567')).toBe(canonical);
+    expect(hashPhone('555 123 4567')).toBe(canonical);
+  });
+
+  it('preserves country code digits (changes the hash)', () => {
+    // +1 prefix produces 11-digit input "15551234567", distinct from 10-digit "5551234567"
+    expect(hashPhone('+1 555-123-4567')).not.toBe(hashPhone('555-123-4567'));
+    expect(hashPhone('+1 (555) 123-4567')).toBe(hashPhone('15551234567'));
+  });
+
+  it('returns undefined when no digits remain after stripping', () => {
+    expect(hashPhone(undefined)).toBeUndefined();
+    expect(hashPhone('')).toBeUndefined();
+    expect(hashPhone('   ')).toBeUndefined();
+    expect(hashPhone('---')).toBeUndefined();
+    expect(hashPhone('()')).toBeUndefined();
+  });
+});
+
+describe('hashName', () => {
+  it('lowercases and trims before hashing', () => {
+    const canonical = hashName('jeremy');
+    expect(hashName('Jeremy')).toBe(canonical);
+    expect(hashName('JEREMY')).toBe(canonical);
+    expect(hashName('  Jeremy  ')).toBe(canonical);
+    expect(hashName('\tJeremy\n')).toBe(canonical);
+  });
+
+  it('returns undefined for empty/missing input', () => {
+    expect(hashName(undefined)).toBeUndefined();
+    expect(hashName('')).toBeUndefined();
+    expect(hashName('   ')).toBeUndefined();
+  });
+
+  it('handles names with internal whitespace (multi-word names)', () => {
+    // "van der Berg" should lowercase the whole thing but keep internal spaces
+    // (Meta spec does not collapse internal whitespace; only leading/trailing trimmed)
+    const a = hashName('Van Der Berg');
+    const b = hashName('van der berg');
+    expect(a).toBe(b);
+  });
+});
+
+describe('sendMetaEvent', () => {
+  const originalFetch = global.fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    process.env.NEXT_PUBLIC_META_PIXEL_ID = '2027401758169466';
+    process.env.META_CAPI_ACCESS_TOKEN = 'test_access_token';
+    delete process.env.META_TEST_EVENT_CODE;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    delete process.env.NEXT_PUBLIC_META_PIXEL_ID;
+    delete process.env.META_CAPI_ACCESS_TOKEN;
+    delete process.env.META_TEST_EVENT_CODE;
+    vi.clearAllMocks();
+  });
+
+  it('returns { ok: true } on 200 response', async () => {
+    fetchMock.mockResolvedValue(new Response('{"events_received":1}', { status: 200 }));
+    const result = await sendMetaEvent({
+      eventName: 'Purchase',
+      userData: { email: 'test@test.com' },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('returns { ok: false, error } when fetch rejects — never throws', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'));
+    // Graceful failure is critical: analytics errors must never break the calling
+    // handler (Stripe webhook, auth callback, etc). This test proves the try/catch
+    // catches network errors instead of bubbling them up.
+    const result = await sendMetaEvent({
+      eventName: 'Purchase',
+      userData: { email: 'test@test.com' },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('network down');
+  });
+
+  it('returns { ok: false } when Meta returns non-2xx', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('{"error":{"message":"Invalid parameter"}}', { status: 400 })
+    );
+    const result = await sendMetaEvent({
+      eventName: 'Purchase',
+      userData: {},
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+
+  it('returns { ok: false } when NEXT_PUBLIC_META_PIXEL_ID is missing (no network call)', async () => {
+    delete process.env.NEXT_PUBLIC_META_PIXEL_ID;
+    const result = await sendMetaEvent({
+      eventName: 'Purchase',
+      userData: {},
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/pixel.?id/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns { ok: false } when META_CAPI_ACCESS_TOKEN is missing (no network call)', async () => {
+    delete process.env.META_CAPI_ACCESS_TOKEN;
+    const result = await sendMetaEvent({
+      eventName: 'Purchase',
+      userData: {},
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/access.?token/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('POSTs to graph.facebook.com with pixel_id in path and access_token in query', async () => {
+    fetchMock.mockResolvedValue(new Response('{}', { status: 200 }));
+    await sendMetaEvent({
+      eventName: 'Purchase',
+      userData: {},
+    });
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toContain('graph.facebook.com');
+    expect(url).toContain('2027401758169466/events');
+    expect(url).toContain('access_token=test_access_token');
+    expect(options.method).toBe('POST');
+    expect(options.headers).toMatchObject({ 'Content-Type': 'application/json' });
+  });
+
+  it('hashes email, phone, firstName, lastName in user_data (arrays per Meta spec)', async () => {
+    fetchMock.mockResolvedValue(new Response('{}', { status: 200 }));
+    await sendMetaEvent({
+      eventName: 'Purchase',
+      userData: {
+        email: 'test@test.com',
+        phone: '555-123-4567',
+        firstName: 'Jeremy',
+        lastName: 'Watt',
+      },
+    });
+    const [, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse(options.body as string);
+    expect(body.data[0].user_data.em).toEqual([hashEmail('test@test.com')]);
+    expect(body.data[0].user_data.ph).toEqual([hashPhone('555-123-4567')]);
+    expect(body.data[0].user_data.fn).toEqual([hashName('Jeremy')]);
+    expect(body.data[0].user_data.ln).toEqual([hashName('Watt')]);
+  });
+
+  it('passes ip and userAgent through unhashed (client_ip_address / client_user_agent)', async () => {
+    fetchMock.mockResolvedValue(new Response('{}', { status: 200 }));
+    await sendMetaEvent({
+      eventName: 'Purchase',
+      userData: {
+        ip: '1.2.3.4',
+        userAgent: 'Mozilla/5.0',
+      },
+    });
+    const [, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse(options.body as string);
+    expect(body.data[0].user_data.client_ip_address).toBe('1.2.3.4');
+    expect(body.data[0].user_data.client_user_agent).toBe('Mozilla/5.0');
+  });
+
+  it('includes test_event_code when META_TEST_EVENT_CODE env var is set', async () => {
+    process.env.META_TEST_EVENT_CODE = 'TEST1234';
+    fetchMock.mockResolvedValue(new Response('{}', { status: 200 }));
+    await sendMetaEvent({ eventName: 'Purchase', userData: {} });
+    const [, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse(options.body as string);
+    expect(body.test_event_code).toBe('TEST1234');
+  });
+
+  it('omits test_event_code when env var is unset (production behavior)', async () => {
+    fetchMock.mockResolvedValue(new Response('{}', { status: 200 }));
+    await sendMetaEvent({ eventName: 'Purchase', userData: {} });
+    const [, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse(options.body as string);
+    expect(body.test_event_code).toBeUndefined();
+  });
+
+  it('defaults eventTime to current unix timestamp in seconds', async () => {
+    fetchMock.mockResolvedValue(new Response('{}', { status: 200 }));
+    const before = Math.floor(Date.now() / 1000);
+    await sendMetaEvent({ eventName: 'Purchase', userData: {} });
+    const after = Math.floor(Date.now() / 1000);
+    const [, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse(options.body as string);
+    expect(body.data[0].event_time).toBeGreaterThanOrEqual(before);
+    expect(body.data[0].event_time).toBeLessThanOrEqual(after);
+  });
+
+  it('includes eventId and eventSourceUrl when provided', async () => {
+    fetchMock.mockResolvedValue(new Response('{}', { status: 200 }));
+    await sendMetaEvent({
+      eventName: 'Purchase',
+      userData: {},
+      eventId: 'stripe_session_abc',
+      eventSourceUrl: 'https://bleepthat.sh/success',
+    });
+    const [, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse(options.body as string);
+    expect(body.data[0].event_id).toBe('stripe_session_abc');
+    expect(body.data[0].event_source_url).toBe('https://bleepthat.sh/success');
+  });
+
+  it('sets action_source to "website" by default', async () => {
+    fetchMock.mockResolvedValue(new Response('{}', { status: 200 }));
+    await sendMetaEvent({ eventName: 'Purchase', userData: {} });
+    const [, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse(options.body as string);
+    expect(body.data[0].action_source).toBe('website');
+  });
+
+  it('includes customData fields in custom_data', async () => {
+    fetchMock.mockResolvedValue(new Response('{}', { status: 200 }));
+    await sendMetaEvent({
+      eventName: 'Purchase',
+      userData: {},
+      customData: { value: 9.99, currency: 'USD' },
+    });
+    const [, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse(options.body as string);
+    expect(body.data[0].custom_data.value).toBe(9.99);
+    expect(body.data[0].custom_data.currency).toBe('USD');
+  });
+
+  it('omits user_data fields for empty/undefined PII (no empty arrays sent)', async () => {
+    // Meta rejects user_data fields with empty string values but tolerates missing
+    // keys. Test that we send { user_data: {} } rather than { user_data: { em: [] } }
+    // when no identifiers are provided.
+    fetchMock.mockResolvedValue(new Response('{}', { status: 200 }));
+    await sendMetaEvent({ eventName: 'Purchase', userData: {} });
+    const [, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse(options.body as string);
+    expect(body.data[0].user_data.em).toBeUndefined();
+    expect(body.data[0].user_data.ph).toBeUndefined();
+    expect(body.data[0].user_data.fn).toBeUndefined();
+    expect(body.data[0].user_data.ln).toBeUndefined();
+  });
+});

--- a/lib/meta/capi.ts
+++ b/lib/meta/capi.ts
@@ -1,0 +1,119 @@
+import { createHash } from 'crypto';
+
+// Meta Conversions API wrapper for bleepthat.sh (Pixel 2027401758169466).
+// Spec: https://developers.facebook.com/docs/marketing-api/conversions-api
+// PII normalization: https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/customer-information-parameters
+
+function sha256Hex(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}
+
+export function hashEmail(email?: string): string | undefined {
+  if (!email) return undefined;
+  const normalized = email.trim().toLowerCase();
+  if (!normalized) return undefined;
+  return sha256Hex(normalized);
+}
+
+export function hashPhone(phone?: string): string | undefined {
+  if (!phone) return undefined;
+  const digitsOnly = phone.replace(/\D/g, '');
+  if (!digitsOnly) return undefined;
+  return sha256Hex(digitsOnly);
+}
+
+export function hashName(name?: string): string | undefined {
+  if (!name) return undefined;
+  const normalized = name.trim().toLowerCase();
+  if (!normalized) return undefined;
+  return sha256Hex(normalized);
+}
+
+export interface MetaUserData {
+  email?: string;
+  phone?: string;
+  firstName?: string;
+  lastName?: string;
+  ip?: string;
+  userAgent?: string;
+}
+
+export interface MetaCustomData {
+  currency?: string;
+  value?: number;
+  contentName?: string;
+  contentCategory?: string;
+  [key: string]: unknown;
+}
+
+export interface SendMetaEventInput {
+  eventName: string;
+  eventTime?: number;
+  userData: MetaUserData;
+  customData?: MetaCustomData;
+  eventId?: string;
+  eventSourceUrl?: string;
+}
+
+export interface SendMetaEventResult {
+  ok: boolean;
+  error?: string;
+}
+
+const META_GRAPH_API_VERSION = 'v21.0';
+
+export async function sendMetaEvent(input: SendMetaEventInput): Promise<SendMetaEventResult> {
+  const pixelId = process.env.NEXT_PUBLIC_META_PIXEL_ID;
+  if (!pixelId) {
+    return { ok: false, error: 'Missing NEXT_PUBLIC_META_PIXEL_ID' };
+  }
+
+  const accessToken = process.env.META_CAPI_ACCESS_TOKEN;
+  if (!accessToken) {
+    return { ok: false, error: 'Missing META_CAPI_ACCESS_TOKEN' };
+  }
+
+  const userData: Record<string, unknown> = {};
+  const em = hashEmail(input.userData.email);
+  if (em) userData.em = [em];
+  const ph = hashPhone(input.userData.phone);
+  if (ph) userData.ph = [ph];
+  const fn = hashName(input.userData.firstName);
+  if (fn) userData.fn = [fn];
+  const ln = hashName(input.userData.lastName);
+  if (ln) userData.ln = [ln];
+  if (input.userData.ip) userData.client_ip_address = input.userData.ip;
+  if (input.userData.userAgent) userData.client_user_agent = input.userData.userAgent;
+
+  const event: Record<string, unknown> = {
+    event_name: input.eventName,
+    event_time: input.eventTime ?? Math.floor(Date.now() / 1000),
+    action_source: 'website',
+    user_data: userData,
+  };
+  if (input.eventId) event.event_id = input.eventId;
+  if (input.eventSourceUrl) event.event_source_url = input.eventSourceUrl;
+  if (input.customData) event.custom_data = input.customData;
+
+  const payload: Record<string, unknown> = { data: [event] };
+  const testEventCode = process.env.META_TEST_EVENT_CODE;
+  if (testEventCode) payload.test_event_code = testEventCode;
+
+  const url = `https://graph.facebook.com/${META_GRAPH_API_VERSION}/${pixelId}/events?access_token=${encodeURIComponent(accessToken)}`;
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => `status ${response.status}`);
+      return { ok: false, error: `Meta API ${response.status}: ${text}` };
+    }
+    return { ok: true };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { ok: false, error: message };
+  }
+}


### PR DESCRIPTION
## Summary

Phase 1 of the Meta Pixel + Conversions API integration (per `docs/plans/meta-pixel-plan.md`). This PR adds the **server-side CAPI wrapper only** — browser Pixel, UI components, event wiring, and consent banner come in subsequent PRs.

**Opening as a draft** so we can land it incrementally once PRs #142 (Doppler cleanup) and #143 (domain migration) merge without worrying about scope creep or merge conflicts during reviews.

## What's in this PR

### `lib/meta/capi.ts` — the wrapper

- **`hashEmail` / `hashPhone` / `hashName`**: SHA-256 helpers per [Meta's customer-information-parameters spec](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/customer-information-parameters). Normalization: trim+lowercase for email/name, digits-only for phone. Empty inputs return `undefined` (keys omitted from payload — Meta rejects empty strings).
- **`sendMetaEvent`**: POSTs a single event to `graph.facebook.com/v21.0/{pixelId}/events`.
  - Hashed arrays: `em`, `ph`, `fn`, `ln` (Meta expects arrays even for single values)
  - Unhashed: `client_ip_address`, `client_user_agent`
  - `test_event_code` injected at top level (not inside `data[]`) only when `META_TEST_EVENT_CODE` is set
  - Graceful failure: returns `{ ok: false, error }` on fetch rejection, non-2xx response, or missing env — **never throws**

### `lib/meta/capi.test.ts` — 24 tests

- **Meta test vector anchor**: `sha256("test@test.com") === f660ab912ec121d1b1e928a0bb4bc61b15f5ad44d5efdc4e1c92a25e99b8e44a`. This exact hash was observed in Meta's own Graph API Explorer sample payload during Pixel setup. If the hashing impl ever silently breaks, this test fails loudly before Meta's server does.
- Graceful failure coverage: network errors, 4xx/5xx responses, missing env vars — all return `{ ok: false }` instead of throwing. Critical for calling sites (Stripe webhook, auth callback) where a thrown analytics error would cascade to the host handler.
- Env-var presence tests: explicitly asserts `fetch` is NOT called when `NEXT_PUBLIC_META_PIXEL_ID` or `META_CAPI_ACCESS_TOKEN` is missing — prevents leaking an unauthenticated request with partial config.
- `test_event_code` placement: top-level of payload, not inside `data[0]` (common Meta quirk; wrong placement silently routes test events to production).

### `docs/plans/meta-pixel-plan.md` — the design doc

Full plan for the whole feature (not just this PR): scope decisions, event taxonomy, file list for subsequent phases, testing strategy, effort estimate. Useful context for reviewing this PR and future ones in the series.

## Dependencies (already provisioned in Vercel)

| Env var | Scope | Status |
|---|---|---|
| `NEXT_PUBLIC_META_PIXEL_ID` | Production + Preview + Development | ✅ Value `2027401758169466` |
| `META_CAPI_ACCESS_TOKEN` | Production + Preview + Development | ✅ Set |
| `META_TEST_EVENT_CODE` | **Development + Preview ONLY** (explicitly NOT Production) | ✅ Set |

## Not in this PR (future phases)

- `lib/meta/events.ts` — typed event builders (`trackCompleteRegistration`, `trackPurchase`)
- `components/MetaPixel.tsx` — browser Pixel loader (mirrors `components/GoogleAnalytics.tsx` pattern)
- `components/MarketingTrackers.tsx` — pathname-based conditional mount wrapper
- `components/CookieConsent.tsx` — EU/UK geo-gated consent banner
- `middleware.ts` changes — geo detection for consent
- Event wiring in `app/auth/callback/route.ts` (CompleteRegistration) and `app/api/webhooks/stripe/route.ts` (Purchase)

## Test plan

- [ ] CI green (980 unit tests currently passing)
- [ ] Manual smoke: once Phase 2+ ships, verify test events appear in Meta's Test Events dashboard using `META_TEST_EVENT_CODE`
- [ ] No regression on existing tests (verified locally via `npx vitest run` — 980 passed, 9 skipped)