### PR TITLE
docs: point live demo to current Bleep tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Just open the app in any modern browser — **no installation or setup required*
 
 ### Live Demo
 
-Visit the deployed app at [https://neonwatty.github.io/bleep-that-shit/](https://neonwatty.github.io/bleep-that-shit/) or run it locally.
+Use Bleep at [https://bleepthat.sh/bleep](https://bleepthat.sh/bleep), or run it locally.
 
 ---
 


### PR DESCRIPTION
## Summary

- update the README Live Demo link to the current Bleep tool
- preserve the legacy GitHub Pages URL for a dedicated handoff page

## Verification

- `git diff --check`
- confirmed the diff changes only README.md